### PR TITLE
ci: add JSON/YAML/schema validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,52 @@
+name: validate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    name: JSON, YAML, and schema conformance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: pip install jsonschema pyyaml
+
+      - name: Validate JSON syntax
+        run: |
+          python -c "import json; json.load(open('schema_json.json', encoding='utf-8'))"
+          python -c "import json; json.load(open('examples_outputs.json', encoding='utf-8'))"
+
+      - name: Validate YAML syntax
+        run: |
+          python -c "import yaml; yaml.safe_load(open('cyber_threat_skill.yaml', encoding='utf-8'))"
+
+      - name: Validate examples conform to schema
+        run: |
+          python <<'PY'
+          import json, sys, jsonschema
+          with open('schema_json.json', encoding='utf-8') as f:
+              schema = json.load(f)
+          with open('examples_outputs.json', encoding='utf-8') as f:
+              data = json.load(f)
+          examples = data.get('examples', data)
+          items = list(examples.items()) if isinstance(examples, dict) else list(enumerate(examples))
+          fails = []
+          for k, v in items:
+              try:
+                  jsonschema.validate(instance=v, schema=schema)
+              except jsonschema.ValidationError as e:
+                  fails.append(f"  [{k}] path={list(e.absolute_path)} :: {e.message[:240]}")
+          if fails:
+              print("FAIL: examples do not validate against schema:")
+              print(*fails, sep="\n")
+              sys.exit(1)
+          print(f"OK: all {len(items)} examples validate against schema")
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ credentials.*
 # Temp files
 *.tmp
 *.bak
+
+# Claude Code scratch files (PR/issue body drafts)
+.pr-body.md
+.issue-comment.md

--- a/contributing.md
+++ b/contributing.md
@@ -33,7 +33,7 @@ Before submitting a PR, validate your changes:
 
 **If you edited YAML:**
 ```bash
-python -c "import yaml; yaml.safe_load(open('cyber_threat_skill.yaml'))"
+python -c "import yaml; yaml.safe_load(open('cyber_threat_skill.yaml', encoding='utf-8'))"
 # No output = success. If error appears, fix it before committing.
 ```
 


### PR DESCRIPTION
## Summary

Three small but legitimate improvements found during a project survey:

1. **Add CI** (`.github/workflows/validate.yml`) — JSON/YAML syntax validation plus full schema-conformance check on every push/PR. The repo had no CI; `contributing.md` asked contributors to run validations locally but nothing enforced them on incoming PRs. Confirmed all 6 examples in `examples_outputs.json` validate cleanly against `schema_json.json` today.
2. **Defensive `encoding="utf-8"`** in the YAML validation command in `contributing.md`. The yaml file is pure ASCII today so the command works on Windows, but this prevents a confusing cp1252 codec error if a future contribution adds non-ASCII content (em-dashes, arrows, etc.).
3. **`.gitignore` hygiene** — add `.pr-body.md` and `.issue-comment.md` patterns. These are temp files Claude Code drafts when composing PR/issue bodies; they're cleaned up in normal flow but a missed cleanup shouldn't pollute commits.

## What I checked but didn't change

- Schema/examples consistency: 6/6 examples validate, no divergence
- Tier-minimum consistency between `cyber_threat_prompt.md` (R1 table) and `cyber_threat_skill.yaml` (`tier_minimums`): match exactly (5/4/3/2/2/3/best-effort/3/3 = 25 MUST-total)
- Coverage badge thresholds match across both files (`FULL` ≥25, `PARTIAL` 13–24, `MINIMAL` <13)
- `python -m json.tool` and `yaml.safe_load(open(...))` (without explicit encoding) work on Windows for current files — initially looked like a bug, isn't one

## Test plan

- [ ] CI workflow triggers on this PR and passes (validate job green)
- [ ] Locally: `python .github/workflows/validate.yml` is parseable as YAML
- [ ] Locally: schema validation script in workflow runs to completion (already verified — 6/6 examples pass)
- [ ] Confirm `.gitignore` correctly excludes `.pr-body.md` if accidentally created

🤖 Generated with [Claude Code](https://claude.com/claude-code)
