### PR TITLE
ci: tighten validate workflow and document CI in contributing

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: JSON, YAML, and schema conformance

--- a/contributing.md
+++ b/contributing.md
@@ -29,6 +29,8 @@ Thank you for your interest in contributing to the Cyber Threat Intelligence Pro
 
 ### Testing Your Changes Locally
 
+> A GitHub Actions workflow ([`validate`](.github/workflows/validate.yml)) runs the same JSON/YAML/schema-conformance checks on every PR. Catching errors locally is faster, but the server check is the source of truth.
+
 Before submitting a PR, validate your changes:
 
 **If you edited YAML:**


### PR DESCRIPTION
## Summary

Three small polish items on the validate workflow added in #4, all from the [`/review` recommendations](https://github.com/kj299/threat-intel/pull/4):

- **`permissions: contents: read`** — workflow doesn't write anything; tighten `GITHUB_TOKEN` scope to read-only per [GitHub Actions hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions). If a future step were compromised, it can't push to the repo or open issues with the token.
- **`concurrency:` with `cancel-in-progress: true`** — a quick second push on top of an open PR now cancels the superseded run instead of queueing.
- **Note in `contributing.md`** — contributors are now told that the same JSON/YAML/schema validation runs server-side on every PR, so a red CI isn't a surprise.

## Test plan

- [ ] CI workflow still passes on this PR
- [ ] `permissions:` and `concurrency:` blocks parse cleanly (verified locally with `yaml.safe_load`)
- [ ] No functional change to validation logic — same checks, same enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
