### PR TITLE
feat: discovery-first SPL/KQL query authoring for detection output (closes #16)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **SIEM query authoring guidance** (`skills/cyber-threat-intel/references/siem-queries.md`, closes #16) — discovery-first, schema-driven Splunk SPL / Sentinel KQL patterns for the report's detection and hunting output. Establishes the SIEM analogue of R3: an agent must emit a **discovery query**, never a guessed `index`/`sourcetype`/table, when the target environment schema is unknown. Includes `tstats`/`Usage`/`getschema` discovery starters and IOC→query patterns (network, file-hash, process/parent-child, registry autorun, named-pipe/WMI), each carrying a `schema_dependency` note. Wired into `SKILL.md` §7, `references/original-prompt.md` Part 5 §7, `references/output-templates.md`, and `spec.yaml` (`threat_hunting_hypothesis.siem_query_rules`). Schema gains an additive, optional `hunting_queries` array (objective, platform, query, `schema_dependency`, assumptions, tuning, validation, `status`); standalone distributions regenerated.
 - **`.gitattributes`** at repo root enforcing LF line endings for text files (`.md`, `.yaml`, `.yml`, `.json`, `.py`, `LICENSE`, `.gitignore`). Required so the CI layout check (which parses `SKILL.md` frontmatter with `text.startswith('---\n')`) does not break on Linux runners when contributors commit from Windows with `core.autocrlf=true`.
 
 ---

--- a/skills/cyber-threat-intel/SKILL.md
+++ b/skills/cyber-threat-intel/SKILL.md
@@ -12,6 +12,7 @@ Produce a structured threat intelligence report. The output must follow the Sour
 - [references/scoring.md](references/scoring.md) — threat scoring formula and priority mapping
 - [references/personas.md](references/personas.md) — six supported personas
 - [references/output-templates.md](references/output-templates.md) — per-persona report sections + the mandatory Source Coverage Ledger template
+- [references/siem-queries.md](references/siem-queries.md) — Splunk SPL / Sentinel KQL query authoring (discovery-first, schema-driven, no invented datasets)
 - [references/compliance-frameworks.md](references/compliance-frameworks.md) — NIST/ISO/PCI/DORA/NYDFS/SOX/GDPR mappings
 - [references/original-prompt.md](references/original-prompt.md) — the long-form prompt (one self-contained document, used directly by non-Claude assistants and by CI as the canonical source for tier-name parity checks; do not delete)
 - [spec.yaml](spec.yaml) — structured spec consumed by CI validators (personas, scoring weights, tier minimums, compliance mappings)
@@ -100,7 +101,7 @@ Persona: <persona>
    - `Detection_Method` ∈ {`registry key`, `event id`, `process name`, `file path`, `named pipe`, `wmi query`} (lowercase, spaces).
    - `Severity` ∈ {`CRITICAL`, `WARNING`, `INFO`} (uppercase).
    - `Detection_Value`: ASCII-only, ≤260 chars, none of `"` `'` `` ` `` `$` `;` `|` `&` `<` `>` `(` `)` `{` `}` `^`.
-7. Detection Rules — YARA / Sigma / KQL / SPL / Snort/Suricata, each with source.
+7. Detection Rules — YARA / Sigma / KQL / SPL / Snort/Suricata, each with source. For SPL/KQL, follow [references/siem-queries.md](references/siem-queries.md): constrain time + dataset first, filter early, prefer documented/normalized schema (CIM / ASIM), and **emit a discovery query — never a guessed `index`/`sourcetype`/table — when the environment schema is unknown** (the SIEM analogue of R3). Attach `schema_dependency`, threshold/tuning, and a validation step to every detection.
 8. Actions Matrix (`priority | action | owner | timeline | investment | risk_addressed | success_metric`). Timelines: P1=0–48h, P2=48h–7d, P3=7–30d, P4=30–90d.
 9. Intelligence Gaps — what couldn't be determined and why.
 10. **Appendix A: Source Coverage Ledger** (R5 — required). One row per tier with `consulted`, `skipped (with reason)`, `met`. Compute total MUST-minimum sources consulted (out of 25) and stamp the matching badge.

--- a/skills/cyber-threat-intel/examples/outputs.json
+++ b/skills/cyber-threat-intel/examples/outputs.json
@@ -201,10 +201,38 @@
           "kql": [
             "DeviceProcessEvents\n| where Timestamp > ago(7d)\n| where FileName =~ \"svchost_update.exe\" or ProcessCommandLine contains \"RTCore64.sys\"\n| project Timestamp, DeviceName, FileName, ProcessCommandLine, InitiatingProcessFileName"
           ]
-        }
+        },
+        "hunting_queries": [
+          {
+            "platform": "sentinel",
+            "language": "kql",
+            "query_kind": "detection",
+            "objective": "Detect LockBit 3.0 BYOVD driver load via vulnerable RTCore64.sys",
+            "query": "DeviceImageLoadEvents\n| where TimeGenerated > ago(7d)\n| where FileName in~ (\"RTCore64.sys\", \"DBUtil_2_3.sys\")\n| project TimeGenerated, DeviceName, FolderPath, SHA256, InitiatingProcessFileName",
+            "schema_dependency": "DeviceImageLoadEvents (Defender XDR). If only Sysmon is onboarded, map to SecurityEvent/Event with EventID 7 and ImageLoaded.",
+            "assumptions": ["MDE advanced hunting tables present", "driver_load telemetry retained 7d"],
+            "tuning": "Allowlist signed legitimate RTCore64.sys deployments by SHA256; alert only on unsigned or unexpected FolderPath.",
+            "validation": "Load the vulnerable driver in an isolated VM and confirm the rule fires before production.",
+            "status": "ready",
+            "source": "The DFIR Report"
+          },
+          {
+            "platform": "splunk",
+            "language": "spl",
+            "query_kind": "discovery",
+            "objective": "Locate the index/sourcetype carrying driver-load telemetry before writing the production detection",
+            "query": "| tstats count where index=* by index, sourcetype\n| search sourcetype=*sysmon* OR sourcetype=*WinEventLog*",
+            "schema_dependency": "Unknown which index receives Sysmon EID 7 / driver loads. Resolve before authoring the production SPL.",
+            "assumptions": ["No internal data dictionary provided"],
+            "tuning": "n/a — discovery query.",
+            "validation": "Confirm the chosen sourcetype emits ImageLoaded with file hashes via: | tstats values(ImageLoaded) where index=CHOSEN_INDEX",
+            "status": "needs_schema",
+            "source": "MITRE ATT&CK"
+          }
+        ]
       }
     },
-    
+
     {
       "persona": "enterprise_executive",
       "name": "Board-Ready Threat Brief",

--- a/skills/cyber-threat-intel/references/original-prompt.md
+++ b/skills/cyber-threat-intel/references/original-prompt.md
@@ -367,6 +367,15 @@ Provide rules in formats applicable to the threats found:
 
 Every rule must reference its source(s).
 
+**SPL/KQL authoring rules (the SIEM analogue of R3 — no fabrication of schema):**
+- Constrain **time + dataset first**, then fielded predicates, then parsing, then aggregation (filter early, parse late, aggregate last).
+- Prefer documented/normalized schema — Splunk CIM data models, Sentinel ASIM / normalized tables — over vendor-specific `sourcetype`s or `rex`/raw-text scans.
+- **Do not invent an `index`, `sourcetype`, or Sentinel table name.** When the target environment schema is unknown, emit a **discovery query** instead and mark the detection `status: needs schema`:
+  - Splunk: `| tstats count where index=* by index, sourcetype`
+  - Sentinel: `Usage | where TimeGenerated > ago(7d) | summarize sum(Quantity) by DataType, Solution`
+  - or `TableName | getschema` to confirm columns before relying on a field.
+- Attach to every detection: `schema_dependency` (datasets/fields assumed), threshold/tuning + false-positive levers, and a **validation** step (detonate in a lab before production). Record any `needs schema` detection in Intelligence Gaps.
+
 ### 8. Actions Matrix
 Fields: `priority (P1/P2/P3/P4) | action | owner | timeline | investment | risk_addressed | success_metric`
 Timelines: P1=0-48h, P2=48h-7d, P3=7-30d, P4=30-90d.

--- a/skills/cyber-threat-intel/references/output-templates.md
+++ b/skills/cyber-threat-intel/references/output-templates.md
@@ -31,7 +31,7 @@ The persona-specific section lists. The Source Coverage Ledger (Appendix A, R5) 
 2. Deployment Priority
 3. High-Confidence IOCs
 4. Detection Rules (CSV, STIX 2.1, pipe-delimited, YARA, Sigma, Snort, KQL, SPL)
-5. Hunting Queries (KQL, SPL)
+5. Hunting Queries (KQL, SPL) — author per [siem-queries.md](siem-queries.md): discovery-first, schema-driven, no invented `index`/`sourcetype`/table; each query carries `schema_dependency` + tuning + a validation step
 6. Response Playbooks
 7. False-Positive Guidance
 8. Appendix A: Source Coverage Ledger

--- a/skills/cyber-threat-intel/references/siem-queries.md
+++ b/skills/cyber-threat-intel/references/siem-queries.md
@@ -1,0 +1,160 @@
+# SIEM Query Authoring (Splunk SPL / Microsoft Sentinel KQL)
+
+How to shape the **detection** and **hunting** queries a threat-intel report emits (`SKILL.md` §7–§"Hunting Queries", `output-templates.md` SOC IOC Package). The rules below are the SIEM analogue of the no-fabrication rule (R3): **never invent a dataset name when discovery is safer.** A query that references an `index`, `sourcetype`, or Sentinel table that does not exist in the reader's environment is as useless — and as misleading — as a fabricated IOC.
+
+These patterns are environment-agnostic by design. They carry placeholders, not guessed production names. The consumer substitutes real dataset/field names (ideally from an internal data dictionary) before running anything.
+
+## Truth order (highest wins)
+
+1. An internal data dictionary URL or excerpt the user supplied.
+2. Explicit dataset/field names the user gave.
+3. Documented normalized schema (Splunk CIM data models; Sentinel ASIM / normalized tables).
+4. **Discovery query** — when none of the above is known.
+
+Do not let a lower-priority guess override a higher-priority fact. If the schema is unknown, emit a *discovery* query and stop — do not emit a confident production query against an invented dataset.
+
+## Golden rules
+
+- **Discovery-first.** Unknown `index`/`sourcetype` (Splunk) or table/connector (Sentinel) → return a discovery starter (below), mark the detection `status: needs schema`, and say what single fact would unblock it. Same weight as R3.
+- **Constrain scope before logic.** Time bound + exact dataset first, then fielded predicates, then parsing, then aggregation. Filter early, parse late, aggregate last.
+- **Fielded over raw.** Prefer documented field names over `rex`/raw-text scans and over ad-hoc `search "string"`.
+- **Every query carries provenance.** Each detection/hunt query in the report carries `source` (the Matrix entry the logic derives from) and a `schema_dependency` note listing the datasets/fields it assumes.
+- **Small results.** Project only needed columns (`| table` / `project`); stop at the smallest useful output.
+- **Prefer normalized models** (CIM / ASIM) when coverage is known; they survive schema drift better than vendor-specific sourcetypes.
+
+## Discovery starters (run these first when schema is unknown)
+
+### Splunk — `tstats` (reads indexed metadata, cheap)
+
+```spl
+| tstats count where index=* by index, sourcetype
+```
+```spl
+| tstats count from datamodel=Endpoint where nodename=Endpoint.Processes by index
+```
+```spl
+| tstats values(YOUR_FIELD) where index=YOUR_INDEX
+```
+An empty `values()` result means the field is not indexed — a raw-event search with extraction is required.
+
+### Sentinel — metadata tables + `getschema`
+
+```kql
+Usage | where TimeGenerated > ago(7d)
+| summarize TotalGB = sum(Quantity) / 1024 by DataType, Solution
+| sort by TotalGB desc
+```
+```kql
+Heartbeat | where TimeGenerated > ago(24h)
+| summarize LastSeen = max(TimeGenerated) by Computer, OSType, Category
+```
+```kql
+TableName | getschema      // columns + types, no event scan
+TableName | take 5         // cheapest look at real values
+```
+
+Return a discovery query (and stop) when: the exact index/sourcetype or table is unknown; a CIM/ASIM detection is requested but model coverage is unclear; or a translation hinges on which index/table receives the source data.
+
+## IOC → query patterns
+
+Placeholders in `<ANGLE_BRACKETS>` are substituted from the data dictionary. Each pattern names the schema it assumes so the consumer can map or run discovery.
+
+### Network IOC match (IP / domain) — `block`/`alert` IOCs as a hunt
+
+Schema assumed: a network/proxy/DNS dataset with `dest_ip`, `dest`/`query` (Splunk CIM `Network_Traffic` / `Web` / `DNS`); Sentinel `CommonSecurityLog` / `DnsEvents` / ASIM `_Im_NetworkSession`.
+
+```spl
+| tstats summariesonly=t count from datamodel=Network_Traffic
+  where All_Traffic.dest_ip IN (<IOC_IP_1>,<IOC_IP_2>) by All_Traffic.src_ip, All_Traffic.dest_ip
+| rename All_Traffic.* AS *
+```
+```kql
+let iocs = dynamic(["<IOC_IP_1>","<IOC_IP_2>"]);
+_Im_NetworkSession(starttime=ago(7d))
+| where DstIpAddr in (iocs)
+| project TimeGenerated, SrcIpAddr, DstIpAddr, Dvc, EventProduct
+```
+
+### File-hash match
+
+Schema assumed: endpoint/file-event dataset with a hash field (CIM `Endpoint.Filesystem` / Sysmon `file_hash`; Sentinel `DeviceFileEvents.SHA256` or ASIM `_Im_FileEvent`).
+
+```spl
+index=<EDR_INDEX> sourcetype=<EDR_SOURCETYPE> (file_hash=<SHA256_1> OR file_hash=<SHA256_2>)
+| table _time, host, user, process_name, file_path, file_hash
+```
+```kql
+let hashes = dynamic(["<SHA256_1>","<SHA256_2>"]);
+DeviceFileEvents
+| where TimeGenerated > ago(7d)
+| where SHA256 in (hashes)
+| project TimeGenerated, DeviceName, InitiatingProcessAccountName, FolderPath, SHA256
+```
+
+### Suspicious process / parent-child (TTP behavior)
+
+Schema assumed: process-creation telemetry (CIM `Endpoint.Processes`; Sysmon EID 1; Sentinel `DeviceProcessEvents` / ASIM `_Im_ProcessCreate`).
+
+```spl
+| tstats summariesonly=t count from datamodel=Endpoint.Processes
+  where Processes.process_name=<CHILD_PROC> Processes.parent_process_name=<PARENT_PROC>
+  by Processes.dest, Processes.user, Processes.process
+| rename Processes.* AS *
+```
+```kql
+DeviceProcessEvents
+| where TimeGenerated > ago(7d)
+| where FileName =~ "<CHILD_PROC>" and InitiatingProcessFileName =~ "<PARENT_PROC>"
+| project TimeGenerated, DeviceName, AccountName, InitiatingProcessFileName, FileName, ProcessCommandLine
+```
+
+### Registry autorun persistence (T1547.001)
+
+Schema assumed: registry telemetry (Sysmon EID 12/13; Sentinel `DeviceRegistryEvents`).
+
+```spl
+index=<EDR_INDEX> sourcetype=<SYSMON_SOURCETYPE> EventCode IN (12,13)
+  registry_path="*\\CurrentVersion\\Run*"
+| table _time, host, user, registry_path, registry_value_name, registry_value_data
+```
+```kql
+DeviceRegistryEvents
+| where TimeGenerated > ago(7d)
+| where RegistryKey has @"\CurrentVersion\Run"
+| project TimeGenerated, DeviceName, RegistryKey, RegistryValueName, RegistryValueData
+```
+
+### Named-pipe / WMI persistence (T1021.002 / T1047)
+
+Schema assumed: Sysmon EID 17/18 (pipes), EID 19/20/21 (WMI); Sentinel `DeviceEvents` (`ActionType` for named-pipe / WMI events).
+
+```spl
+index=<EDR_INDEX> sourcetype=<SYSMON_SOURCETYPE> EventCode IN (17,18) pipe_name=<NAMED_PIPE>
+| table _time, host, process_name, pipe_name
+```
+```kql
+DeviceEvents
+| where TimeGenerated > ago(7d)
+| where ActionType in ("NamedPipeEvent","WmiBindEvent")
+| where AdditionalFields has "<NAMED_PIPE_OR_WMI_FILTER>"
+| project TimeGenerated, DeviceName, ActionType, InitiatingProcessFileName, AdditionalFields
+```
+
+## Detection output shape
+
+When the report emits a **detection** (not just a hunt), attach the operational metadata that makes it deployable. Match the structured `hunting_queries` schema (objective, platform, query, schema_dependency, assumptions, tuning, validation):
+
+- **Objective** — the analyst goal in one line.
+- **Query** — the SPL/KQL above with placeholders resolved (or a discovery query if unresolved).
+- **schema_dependency** — datasets + fields the query assumes; the single fact that would remove ambiguity.
+- **Assumptions** — normalized vs raw, time window, parser/connector caveats.
+- **Tuning** — threshold options, false-positive levers, suppression ideas, field substitutions for alternate schemas.
+- **Validate** — how to confirm it fires (detonate the TTP in a lab, replay a known-bad sample) before production.
+
+## Translation (SPL ⇄ KQL)
+
+Preserve intent before syntax: map scope → filters → parsing → aggregation. If no safe one-to-one mapping exists (e.g. the SPL index has no documented Sentinel table equivalent), say so and provide the closest operational pattern plus a discovery query — do not assert a table name on faith.
+
+## Honesty parity
+
+Unknown schema is marked, never guessed — the SIEM counterpart of R3. A detection that depends on an unverified `index`/`sourcetype`/table is emitted as a discovery query with `status: needs schema`, recorded in Intelligence Gaps, and never stamped as a ready-to-deploy rule.

--- a/skills/cyber-threat-intel/schemas/output.schema.json
+++ b/skills/cyber-threat-intel/schemas/output.schema.json
@@ -739,6 +739,60 @@
             }
           }
         },
+        "hunting_queries": {
+          "type": "array",
+          "description": "Structured SPL/KQL hunt or detection queries shaped per references/siem-queries.md. Unknown environment schema MUST yield query_kind=discovery with status=needs_schema, never a guessed index/sourcetype/table.",
+          "items": {
+            "type": "object",
+            "required": ["platform", "objective", "query", "source"],
+            "properties": {
+              "platform": {
+                "type": "string",
+                "enum": ["splunk", "sentinel"]
+              },
+              "language": {
+                "type": "string",
+                "enum": ["spl", "kql"]
+              },
+              "query_kind": {
+                "type": "string",
+                "enum": ["hunt", "detection", "triage", "discovery", "translation"],
+                "default": "hunt"
+              },
+              "objective": { "type": "string" },
+              "query": {
+                "type": "string",
+                "minLength": 1
+              },
+              "schema_dependency": {
+                "type": "string",
+                "description": "Datasets/fields the query assumes; the single fact that would remove ambiguity"
+              },
+              "assumptions": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "tuning": {
+                "type": "string",
+                "description": "Threshold options, false-positive levers, suppression ideas, field substitutions"
+              },
+              "validation": {
+                "type": "string",
+                "description": "How to confirm the query fires before production (lab detonation / known-bad replay)"
+              },
+              "status": {
+                "type": "string",
+                "enum": ["ready", "needs_schema", "needs_validation"],
+                "default": "ready"
+              },
+              "source": {
+                "type": "string",
+                "minLength": 1,
+                "not": { "enum": ["unknown", "general knowledge", "n/a"] }
+              }
+            }
+          }
+        },
         "doze_sec_iocs": {
           "type": "array",
           "description": "Pipe-delimited IOC lines for doze_sec batch audit tool. Format: MITRE_ID|Name|Detection_Method|Detection_Value|Severity|Actor",

--- a/skills/cyber-threat-intel/spec.yaml
+++ b/skills/cyber-threat-intel/spec.yaml
@@ -312,6 +312,14 @@ analysis_modules:
   threat_hunting_hypothesis:
     methodology: intelligence_driven_hunting
     query_formats: [kql, spl, sigma, yara]
+    # SPL/KQL authoring guardrails. Detail in references/siem-queries.md.
+    siem_query_rules:
+      schema_truth_order: [internal_data_dictionary, user_provided_names, normalized_schema_cim_asim, discovery_query]
+      discovery_first: true   # unknown index/sourcetype/table -> discovery query, never a guessed name (SIEM analogue of R3)
+      filter_early_parse_late: true
+      prefer_normalized: [splunk_cim, sentinel_asim]
+      per_detection_metadata: [schema_dependency, threshold, false_positive_levers, validation_step, source]
+      unresolved_status: needs_schema   # recorded in intelligence_gaps
 
   vulnerability_chaining:
     steps: [inventory, map_dependencies, identify_chains, score_chains, recommend_breaks]

--- a/standalone/cyber-threat-intel-prompt.md
+++ b/standalone/cyber-threat-intel-prompt.md
@@ -455,6 +455,11 @@ Provide rules in formats applicable to the threats found:
 
 Every rule must reference its source(s).
 
+**SPL/KQL authoring rules (the SIEM analogue of R3 — no fabrication of schema):** constrain time + dataset first, then fielded predicates, then parsing, then aggregation (filter early, parse late, aggregate last). Prefer documented/normalized schema (Splunk CIM, Sentinel ASIM) over vendor `sourcetype`s or `rex`/raw-text scans. **Do not invent an `index`, `sourcetype`, or Sentinel table name** — when the environment schema is unknown, emit a **discovery query** and mark the detection `status: needs schema`:
+- Splunk: `| tstats count where index=* by index, sourcetype`
+- Sentinel: `Usage | where TimeGenerated > ago(7d) | summarize sum(Quantity) by DataType, Solution`, or `TableName | getschema` to confirm columns.
+Attach to every detection: `schema_dependency` (datasets/fields assumed), threshold/tuning + false-positive levers, and a **validation** step (lab detonation before production). Record any `needs schema` detection in Intelligence Gaps.
+
 ### 8. Actions Matrix
 Fields: `priority (P1/P2/P3/P4) | action | owner | timeline | investment | risk_addressed | success_metric`
 Timelines: P1=0–48h, P2=48h–7d, P3=7–30d, P4=30–90d.

--- a/standalone/cyber-threat-intel-skill.md
+++ b/standalone/cyber-threat-intel-skill.md
@@ -233,7 +233,7 @@ Persona: <persona>
      - `Detection_Method` ∈ {`registry key`, `event id`, `process name`, `file path`, `named pipe`, `wmi query`} (lowercase, spaces — not underscores).
      - `Severity` ∈ {`CRITICAL`, `WARNING`, `INFO`} (uppercase).
      - `Detection_Value`: ASCII-only, ≤260 chars, none of `"` `'` `` ` `` `$` `;` `|` `&` `<` `>` `(` `)` `{` `}` `^`.
-7. **Detection Rules** — YARA / Sigma / KQL / SPL / Snort/Suricata, each with `source`.
+7. **Detection Rules** — YARA / Sigma / KQL / SPL / Snort/Suricata, each with `source`. For SPL/KQL: constrain time + dataset first, filter early, prefer normalized schema (CIM / ASIM), and **emit a discovery query — never a guessed `index`/`sourcetype`/table — when the environment schema is unknown** (the SIEM analogue of R3). Attach `schema_dependency`, threshold/tuning, and a validation step to every detection; record `needs schema` detections in Intelligence Gaps.
 8. **Actions Matrix** — `priority | action | owner | timeline | investment | risk_addressed | success_metric`. Timelines: P1=0–48h, P2=48h–7d, P3=7–30d, P4=30–90d.
 9. **Intelligence Gaps** — what couldn't be determined and why.
 10. **Appendix A: Source Coverage Ledger** (R5 — required, template below).


### PR DESCRIPTION
﻿Closes #16.

## What

Makes the report's SPL/KQL detection and hunting output robust by baking the `splunk-sentinel-query-builder` principles into the cyber-intel skill. The headline rule: **the SIEM analogue of R3** — never invent an `index`, `sourcetype`, or Sentinel table; when the target schema is unknown, emit a *discovery* query and mark the detection `needs_schema`.

## Changes

- **New** `skills/cyber-threat-intel/references/siem-queries.md` — truth order, golden rules (discovery-first, filter-early/parse-late, no invented datasets, provenance per query), `tstats`/`Usage`/`getschema` discovery starters, and IOC→query patterns (network, file-hash, process/parent-child, registry autorun, named-pipe/WMI) for both SPL and KQL with placeholders + `schema_dependency` notes.
- **Wired in**: `SKILL.md` §7, `references/original-prompt.md` Part 5 §7, `references/output-templates.md` (SOC IOC Package), `spec.yaml` (`threat_hunting_hypothesis.siem_query_rules`).
- **Schema**: additive, **optional** `hunting_queries` array (objective, platform, query, `schema_dependency`, assumptions, tuning, validation, `status`, source). Existing `detection_rules.kql/.spl` string arrays unchanged.
- **Example**: `enterprise_soc` gains two `hunting_queries` — a ready Sentinel detection and a `needs_schema` Splunk discovery query.
- **Standalone** prompt + skill regenerated; **changelog** entry under `[Unreleased]`.

## Validation

Ran the CI jobs locally (layout/frontmatter, JSON/YAML syntax, examples-vs-schema, version/persona/coverage-ledger/tier parity, 19 negative fixtures): **all pass**. No version bump (changes accumulate under `[Unreleased]`, matching repo convention), so version parity stays at `1.1.0`.

## Merge-order note

This PR is the **base of a 3-PR stack**. Merge order: **#19 -> #20 -> #21**. #19 targets `main`; #20 is based on this branch and #21 on #20's branch, so each PR's diff shows only its own changes and they merge in sequence with **zero conflicts**. When #19 merges, GitHub auto-retargets #20 to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


