### PR TITLE
docs: sync root docs with the SIEM/CWE/R6 additions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,11 @@ The skill follows the [Anthropic Agent Skills](https://code.claude.com/docs/en/s
 - `skills/cyber-threat-intel/references/` -- supporting reference docs loaded only when needed
   - `source-matrix.md` -- the full named source list across 9 tiers (R1/R2 enforcement)
   - `extraction-framework.md` -- IOC, TTP, actor, and forecast field schemas
+  - `cwe-chaining.md` -- weakness-class (CWE) chaining for AI-assisted attacks, with defensive break-points
   - `scoring.md` -- threat scoring formula and priority mapping
   - `personas.md` -- the 6 supported personas
   - `output-templates.md` -- per-persona section lists and the mandatory Source Coverage Ledger template
+  - `siem-queries.md` -- Splunk SPL / Sentinel KQL authoring (discovery-first, schema-driven, no invented datasets)
   - `compliance-frameworks.md` -- NIST/ISO/PCI/DORA/NYDFS/SOX/GDPR mappings
   - `original-prompt.md` -- the original long-form prompt, kept for non-Claude assistants and as the canonical source for tier-name parity checks
 - `skills/cyber-threat-intel/schemas/output.schema.json` -- JSON Schema for validating structured output

--- a/README.md
+++ b/README.md
@@ -87,15 +87,20 @@ threat-intel/
         +-- references/
         |   +-- source-matrix.md                      # 150+ named sources across 9 tiers
         |   +-- extraction-framework.md               # IOC/TTP/actor field schemas
+        |   +-- cwe-chaining.md                       # CWE-chain analysis (AI-assisted) + break-points
         |   +-- scoring.md                            # scoring formula + priority mapping
         |   +-- personas.md                           # 6 supported personas
         |   +-- output-templates.md                   # per-persona report sections
+        |   +-- siem-queries.md                       # SPL/KQL authoring: discovery-first, schema-driven
         |   +-- compliance-frameworks.md              # NIST/ISO/PCI/DORA/NYDFS/SOX/GDPR
         |   +-- original-prompt.md                    # long-form prompt for non-Claude assistants
         +-- schemas/
         |   +-- output.schema.json                    # JSON Schema for output validation
         +-- examples/
             +-- outputs.json                          # one example per persona
++-- standalone/                                      # flattened single-file distributions
+    +-- cyber-threat-intel-prompt.md                 # self-contained prompt (any LLM)
+    +-- cyber-threat-intel-skill.md                  # self-contained Agent Skill
 ```
 
 ---

--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **CWE-chaining analysis for AI-assisted attacks** (`skills/cyber-threat-intel/references/cwe-chaining.md`, closes #18) — the skill previously reasoned only about multi-CVE exploit chains; it now models **weakness-class (CWE) chains** (primary → resultant, MITRE CWE-1000 view) with a mandatory defensive **break-point** per chain. Each chain records an `ai_assist_factor` (none/low/moderate/high) capturing how much AI tooling lowers the attacker's cost — paired with a defensive takeaway, never operational uplift. Adds `cwe_ids` to the New Attack Method schema (`attack_method`) and an additive, optional `cwe_chains` array to `skill_output`; expands `spec.yaml` (`vulnerability_chaining.cwe_chaining`, new `ai_assisted_attack_analysis` module); wires a Part 3.E subsection into `references/original-prompt.md`, a §D entry into `references/extraction-framework.md`, and workflow guidance into `SKILL.md`; adds an illustrative SSRF→credential CWE chain to the red_team example. Standalone distributions regenerated.
 - **`.gitattributes`** at repo root enforcing LF line endings for text files (`.md`, `.yaml`, `.yml`, `.json`, `.py`, `LICENSE`, `.gitignore`). Required so the CI layout check (which parses `SKILL.md` frontmatter with `text.startswith('---\n')`) does not break on Linux runners when contributors commit from Windows with `core.autocrlf=true`.
 
+### Fixed
+
+- **Doc consistency after the SIEM/CWE/R6 work**: the `README.md` directory tree and `CLAUDE.md` reference list now enumerate the two new reference files (`references/siem-queries.md`, `references/cwe-chaining.md`), the README tree now also shows the `standalone/` distributions, and `contributing.md` now says "source coverage rules (R1-R6)" (an R6 was added) and reminds contributors to update both `standalone/` files.
+
 ---
 
 ## [1.1.0] - 2026-04-26

--- a/contributing.md
+++ b/contributing.md
@@ -62,7 +62,7 @@ grep -r "\[.*\](.*\.md)" *.md skills/ | grep -i CHANGELOG
 **After editing the prompt or skill file:**
 - Read through the full file to ensure changes are reflected consistently
 - If you add a source, verify it's tagged `[MUST]` or `[SHOULD]` in `skills/cyber-threat-intel/references/source-matrix.md` *and* `skills/cyber-threat-intel/references/original-prompt.md`
-- If you modify source coverage rules (R1-R5), update all references in `SKILL.md`, `references/`, `original-prompt.md`, and `spec.yaml`
+- If you modify source coverage rules (R1-R6), update all references in `SKILL.md`, `references/`, `original-prompt.md`, `spec.yaml`, and both `standalone/` distributions
 
 **If you bumped the version:**
 The version string lives in four places. CI fails if they disagree. Bump all four together (source of truth: `skills/cyber-threat-intel/spec.yaml` -> `skill.version`):


### PR DESCRIPTION
## What

Follow-up to #19/#20/#21. A cross-surface consistency audit of `main` (the canonical skill, both `standalone/` distributions, and the root docs) found everything structurally consistent **except** the root docs, which still predated the new reference files and the R6 rule.

## Findings fixed

| File | Gap | Fix |
|------|-----|-----|
| `README.md` | directory tree omitted `references/siem-queries.md` and `references/cwe-chaining.md` (and never showed `standalone/`) | added all three |
| `CLAUDE.md` | references list omitted the two new files | added them |
| `contributing.md` | "source coverage rules (R1-R5)" — an **R6** now exists | → "(R1-R6)"; also reminds contributors to update both `standalone/` files |
| `changelog.md` | — | `Fixed` entry under `[Unreleased]` |

## What was already consistent (verified, no change needed)

R1–R6 rule presence across all four prose surfaces · per-tier source minimums · the 6-persona set (spec / schema enum / personas.md / examples / both standalone) · doze_sec detection methods + severities (6 surfaces) · coverage-badge thresholds (25/13) · version `1.1.0` (spec / schema / examples / changelog) · the new-feature wiring (SIEM discovery, CWE chaining, `hunting_queries`, `cwe_chains`, `ai_assisted_attack_analysis`) · standalone-skill frontmatter == canonical · no real broken relative links.

## Scope / validation

Docs-only — **no** skill/schema/spec/example/reference bytes changed, so all CI parity checks are unaffected (changelog's first `## [X.Y.Z]` stays `1.1.0`). Targets `main` directly (no stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
