### PR TITLE
Fix consistency issues found by code review of the 1.3.0 reframe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ The skill follows the [Anthropic Agent Skills](https://code.claude.com/docs/en/s
 - `skills/cyber-threat-intel/SKILL.md` -- skill entrypoint with YAML frontmatter (name, description) and the workflow Claude follows
 - `skills/cyber-threat-intel/spec.yaml` -- structured spec (personas, scoring, source-tier minimums, compliance mappings); consumed by CI validators
 - `skills/cyber-threat-intel/references/` -- supporting reference docs loaded only when needed
-  - `source-matrix.md` -- the full named source list across 9 tiers (R1/R2 enforcement)
+  - `source-matrix.md` -- the full named source list across 9 tiers (R1/R2 guidance)
   - `extraction-framework.md` -- IOC, TTP, actor, and forecast field schemas
   - `cwe-chaining.md` -- weakness-class (CWE) chaining for AI-assisted attacks, with defensive break-points
   - `scoring.md` -- threat scoring formula and priority mapping

--- a/contributing.md
+++ b/contributing.md
@@ -126,8 +126,8 @@ Updates compliance mapping reference from ID.RA-1 to RS.AN-2 per NIST CSF 2.0 sp
 
 docs: clarify source coverage protocol in README
 
-Expands explanation of R1-R5 enforcement rules with examples.
-Adds note about MUST vs SHOULD source priorities.
+Expands explanation of the R1-R6 source-coverage guidance with examples.
+Adds note about preferred (MUST) vs optional (SHOULD) source priorities.
 ```
 
 Format: `<type>: <description>` where type is one of:

--- a/docs.md
+++ b/docs.md
@@ -97,7 +97,7 @@ The skill references sources organized by priority:
 
 These are references for the AI to draw from based on its training data. There are no live API integrations.
 
-> The table above shows examples per tier for orientation. **The complete source matrix used for coverage enforcement (R1–R5) lives in [skills/cyber-threat-intel/references/source-matrix.md](skills/cyber-threat-intel/references/source-matrix.md) -- that file is the single source of truth.** Update it there; do not duplicate the matrix in this document. The original-prompt.md file is the canonical source for tier-name parity checks in CI.
+> The table above shows examples per tier for orientation. **The complete source matrix referenced by the source-coverage guidance (R1–R6) lives in [skills/cyber-threat-intel/references/source-matrix.md](skills/cyber-threat-intel/references/source-matrix.md) -- that file is the single source of truth.** Update it there; do not duplicate the matrix in this document. The original-prompt.md file is the canonical source for tier-name parity checks in CI.
 
 ## Threat Scoring
 

--- a/skills/cyber-threat-intel/references/output-templates.md
+++ b/skills/cyber-threat-intel/references/output-templates.md
@@ -2,7 +2,7 @@
 
 The persona-specific section lists. The Source Coverage Ledger (Appendix A, R5) belongs in every template.
 
-The `build_iocs_and_queries` input (default: yes) applies to **all** templates below, not just the SOC IOC Package. When it is off, omit the generated-artifact sections from whichever template is in use — IOC packages/summaries, detection rules, and hunting queries — and keep the narrative sections (executive summary, threat landscape, risk dashboard, recommendations, ledger). The Source Coverage Ledger is still included.
+The `build_iocs_and_queries` input (default: on) applies to **all** templates below, not just the SOC IOC Package. When it is off, drop each template's generated-artifact sections — IOC packages/summaries, detection rules, and hunting queries — and keep that template's remaining narrative and advisory sections; always keep the Source Coverage Ledger (Appendix A). Concretely: the SOC IOC Package keeps Header, Deployment Priority, Response Playbooks, False-Positive Guidance, and the Ledger; the Technical Report drops IOC Summary and Detection Recommendations; the Executive Brief and Personal Security Guide have no generated-artifact sections, so they are unaffected.
 
 ## Executive Brief (max 2 pages)
 

--- a/skills/cyber-threat-intel/references/source-matrix.md
+++ b/skills/cyber-threat-intel/references/source-matrix.md
@@ -2,7 +2,7 @@
 
 The full enumeration of named intelligence sources organized by tier. Supports Rule **R1** (per-tier source coverage targets) and Rule **R2** (every IOC/TTP/claim cites a source naming a specific entry below).
 
-Format: `name — domain — what it provides [MUST | SHOULD]`. `[MUST]` marks preferred sources to draw on first toward a tier's coverage target; `[SHOULD]` marks optional sources that count once the preferred ones are covered. These are priorities, not quotas — see the Source Coverage Protocol.
+Format: `name — domain — what it provides [MUST | SHOULD]`. `[MUST]` marks preferred sources to draw on first toward a tier's coverage target; `[SHOULD]` marks optional sources to add once the preferred ones are covered. These are priorities, not quotas — see the Source Coverage Protocol in [`original-prompt.md`](original-prompt.md).
 
 ## Tier 1: Vulnerability Databases & Exploit Repositories
 - NVD — nvd.nist.gov — CVE records, CVSS scores [MUST]

--- a/skills/cyber-threat-intel/spec.yaml
+++ b/skills/cyber-threat-intel/spec.yaml
@@ -2,7 +2,7 @@
 # CYBER THREAT INTELLIGENCE - STRUCTURED SKILL SPECIFICATION
 # Version: 1.3.0
 # =============================================================================
-# Defines personas, scoring models, source-coverage enforcement, and output
+# Defines personas, scoring models, source-coverage guidance, and output
 # templates. Consumed by CI validators (version/persona/coverage-ledger/tier
 # parity checks). The Anthropic Agent Skill identifier ("cyber-threat-intel")
 # and machine-readable description live in SKILL.md frontmatter, NOT here.
@@ -69,12 +69,14 @@ source_coverage_protocol:
 
   must_minimum_total: 25
 
-  # Honest self-report of coverage depth, not a pass/fail gate. The numeric
-  # thresholds keep the badge well-defined (and drive the CI ledger check);
-  # MINIMAL on a genuinely sparse scope/time range is the correct outcome.
+  # Honest self-report of coverage depth, not a pass/fail gate. Thresholds are
+  # source counts; the CI ledger check derives the same FULL/PARTIAL/MINIMAL
+  # boundaries from must_minimum_total above (FULL at >=must_minimum_total,
+  # PARTIAL at >=ceil/2), not by parsing these strings. MINIMAL on a genuinely
+  # sparse scope/time range is the correct outcome.
   coverage_badges:
     FULL:
-      threshold: "~25+ preferred sources consulted"
+      threshold: ">=25 preferred sources consulted"
       meaning: "Broad coverage; most tier targets met"
     PARTIAL:
       threshold: "13-24 preferred sources consulted"
@@ -394,6 +396,11 @@ analysis_modules:
 
 # =============================================================================
 # OUTPUT TEMPLATES
+# The build_iocs_and_queries input (default true) gates the generated-artifact
+# sections of EVERY template below, not just soc_ioc_package: when false, drop
+# ioc_summary / high_confidence_iocs / detection_rules / detection_recommendations
+# / hunting_queries and keep the rest (always keep appendix_coverage_ledger).
+# executive_brief and personal_security_guide have no such sections.
 # =============================================================================
 output_templates:
 
@@ -403,6 +410,7 @@ output_templates:
 
   technical_report:
     sections: [header_with_coverage_badge, executive_summary, threat_landscape, vulnerability_analysis, ioc_summary, ttp_mapping, threat_actor_profiles, detection_recommendations, mitigation_priorities, technical_appendix, appendix_coverage_ledger]
+    build_toggle: build_iocs_and_queries   # when false, drop ioc_summary + detection_recommendations
 
   personal_security_guide:
     sections: [current_threats_affecting_you, simple_action_checklist, why_this_matters, step_by_step_guides, resources_for_learning, appendix_coverage_ledger]
@@ -412,7 +420,7 @@ output_templates:
     sections: [header_with_coverage_badge, deployment_priority, high_confidence_iocs, detection_rules, hunting_queries, response_playbooks, false_positive_guidance, appendix_coverage_ledger]
     ioc_formats: [csv, stix_2.1, json, yara, sigma, snort]
     query_formats: [kql, spl]
-    build_toggle: build_iocs_and_queries   # default true; when false, omit generated IOC/query artifacts
+    build_toggle: build_iocs_and_queries   # when false, drop high_confidence_iocs + detection_rules + hunting_queries
 
   # Delimited / batch exports for downstream tools: emit clean structured rows
   # and leave input validation + sanitization to the consuming tool. The

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -12,7 +12,7 @@ Two self-contained files. No sibling references, no `spec.yaml`, no schema files
 Both files embed everything previously split across `skills/cyber-threat-intel/references/` and `spec.yaml`:
 
 - The R1–R6 Source Coverage Protocol (strong guidance, not a hard gate)
-- The full 9-tier Source Matrix (the prompt has the long-form list; the skill has a tighter version with the same MUST sources and SHOULD groups)
+- The full 9-tier Source Matrix (the prompt has the long-form list; the skill has a tighter version with the same preferred `[MUST]` sources and optional `[SHOULD]` sources)
 - IOC / TTP / actor / forecast / business-risk extraction schemas
 - Threat scoring formula and P1–P5 priority mapping
 - All 6 personas and their section lists
@@ -23,7 +23,7 @@ Both files embed everything previously split across `skills/cyber-threat-intel/r
 
 - **No JSON Schema.** The structured `output.schema.json` in the main skill is for CI validation. A standalone prompt or skill running in a chat doesn't need it; the field shapes are described inline.
 - **No examples file.** The main skill's `examples/outputs.json` is for schema validation in CI, not few-shot prompting.
-- **No `spec.yaml`.** All persona profiles, scoring weights, and tier minimums that lived there are inlined as tables.
+- **No `spec.yaml`.** All persona profiles, scoring weights, and per-tier coverage targets that lived there are inlined as tables.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

Follow-up to the `/code-review` (fable model) of #25. That review found the #25 fix commit closed the big drift but introduced a few smaller ones of its own, plus some stale framing the consistency sweep never reached. This PR fixes all of it. Single commit, 7 files, +22/−14.

## Fixes (grouped as reviewed)

**(a) `build_iocs_and_queries` toggle note**
- `output-templates.md`: the note over-claimed "applies to all templates" with a keep-list (executive summary / threat landscape / risk dashboard…) that doesn't exist in the **SOC IOC Package** (the enterprise_soc default) or the Personal Security Guide. Reworked into a concrete per-template **drop-list** that names the SOC case explicitly; changed "(default: yes)" → "(default: on)" since the structured key is boolean.
- `spec.yaml`: added a header comment on `output_templates` and a `build_toggle` annotation to `technical_report` so the structured spec matches the prose (previously only `soc_ioc_package` carried it).

**(b) `coverage_badges` block (`spec.yaml`)**
- Restored the **exact** FULL threshold `>=25` (was the fuzzy `~25+`, which overlapped PARTIAL's `13-24` and the strict CI ledger check that stamps FULL only at `total >= 25`).
- Corrected the comment that wrongly claimed the threshold strings "drive the CI ledger check" — the boundaries derive from `must_minimum_total`, not from parsing these strings.

**(c) Dangling reference**
- `source-matrix.md` ended "…see the Source Coverage Protocol." but this file is loaded standalone and contains no such section/link. Pointed it at `original-prompt.md`, which does.

**(d) Residual "enforcement / R1–R5" framing**
- Swept stale wording in `docs.md` (the source-matrix callout: "coverage enforcement (R1–R5)" → "source-coverage guidance (R1–R6)"), `CLAUDE.md` (`source-matrix.md … (R1/R2 enforcement)` → guidance), `standalone/README.md` ("tier minimums" / "MUST sources and SHOULD groups"), `contributing.md` (sample-commit text was "R1-R5 enforcement rules"), and the `spec.yaml` file-header comment.

## Validation
Re-ran the CI checks locally after the edits: YAML parse, version consistency (`1.3.0`), tier parity (1–9 across prompt/spec/schema), persona parity (6), and all 19 negative fixtures still rejected. The example-1 coverage ledger still resolves to `FULL` (27 ≥ 25). No CI-relevant surface (tier headings, schema shape, examples, versions, persona set, ledger math) changed.

https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ)_