### PR TITLE
Repo housekeeping: CI for mcp/, documentation, feed consistency check

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -397,8 +397,13 @@ jobs:
           if feed_q is None:
               print("SKIP: no feed_integrations question in spec.yaml initial_questions")
               sys.exit(0)
-          example_text = feed_q.get('example', '')
-          feeds = [t.strip().strip('"\'') for t in re.split(r'[,;]', example_text) if t.strip()]
+          example = feed_q.get('example', '')
+          if isinstance(example, list):
+              feeds = [item['name'].strip() for item in example if isinstance(item, dict) and item.get('name')]
+          elif isinstance(example, str):
+              feeds = [t.strip().strip('"\'') for t in re.split(r'[,;]', example) if t.strip()]
+          else:
+              feeds = []
           if not feeds:
               print("SKIP: feed_integrations example is empty; nothing to cross-check")
               sys.exit(0)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -384,6 +384,37 @@ jobs:
           print(f"OK: {len(reference)} tiers numbered consistently across prompt, spec, and schema, with overlapping names")
           PY
 
+      - name: Feed-integrations source consistency
+        run: |
+          python <<'PY'
+          import os, pathlib, re, sys, yaml
+          spec = yaml.safe_load(open(os.environ['SPEC_FILE'], encoding='utf-8'))
+          feed_q = next(
+              (q for q in spec.get('user_inputs', {}).get('initial_questions', [])
+               if q.get('name') == 'feed_integrations'),
+              None,
+          )
+          if feed_q is None:
+              print("SKIP: no feed_integrations question in spec.yaml initial_questions")
+              sys.exit(0)
+          example_text = feed_q.get('example', '')
+          feeds = [t.strip().strip('"\'') for t in re.split(r'[,;]', example_text) if t.strip()]
+          if not feeds:
+              print("SKIP: feed_integrations example is empty; nothing to cross-check")
+              sys.exit(0)
+          matrix = pathlib.Path('skills/cyber-threat-intel/references/source-matrix.md').read_text(encoding='utf-8')
+          original = pathlib.Path(os.environ['PROMPT_FILE']).read_text(encoding='utf-8')
+          missing = []
+          for feed in feeds:
+              slug = re.sub(r'\s+', '', feed).lower()
+              if not any(re.search(re.escape(feed), text, re.IGNORECASE) for text in (matrix, original)):
+                  missing.append(feed)
+          if missing:
+              print(f"FAIL: feed(s) in spec feed_integrations example not found in source-matrix or original-prompt: {missing}")
+              sys.exit(1)
+          print(f"OK: {len(feeds)} feed(s) from spec feed_integrations example found in source docs: {feeds}")
+          PY
+
       - name: Negative schema fixtures (tests/invalid)
         run: |
           python <<'PY'
@@ -440,3 +471,27 @@ jobs:
               sys.exit(1)
           print(f"OK: all {checked} invalid fixtures correctly rejected")
           PY
+
+  mcp-tests:
+    name: MCP server tests and lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package and dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: python -m pytest tests/ -v --tb=short
+
+      - name: Lint (ruff)
+        run: |
+          pip install ruff
+          ruff check src/ tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,12 @@ The skill follows the [Anthropic Agent Skills](https://code.claude.com/docs/en/s
 - `skills/cyber-threat-intel/schemas/output.schema.json` -- JSON Schema for validating structured output
 - `skills/cyber-threat-intel/examples/outputs.json` -- one example output per persona
 - `tests/invalid/` -- negative schema fixtures (must be rejected)
-- `.github/workflows/validate.yml` -- CI: layout, JSON/YAML syntax, schema conformance, version parity, persona parity, coverage-ledger consistency, tier parity, negative fixtures
+- `.github/workflows/validate.yml` -- CI: layout, JSON/YAML syntax, schema conformance, version parity, persona parity, coverage-ledger consistency, tier parity, feed consistency, negative fixtures; second job runs `mcp/` pytest suite + ruff lint
+- `mcp/` -- `threat-intel-mcp` MCP server (stdio transport); runtime counterpart to the prompt skill
+  - `mcp/src/threat_intel_mcp/adapters/qfeeds.py` -- Q-Feeds HTTP adapter (paginated fetch, 20-min cache, ioc_network normalisation)
+  - `mcp/src/threat_intel_mcp/vault/` -- credential provider abstraction; Phase 1 = `EnvCredentialProvider` (reads `QFEEDS_API_KEY`)
+  - `mcp/src/threat_intel_mcp/server.py` -- FastMCP entry point exposing `qfeeds_fetch_iocs` and `list_available_feeds`
+  - `mcp/tests/` -- 31 unit + httpx-mock integration tests (no live network)
 
 Repo-root `README.md`, `LICENSE`, `CLAUDE.md`, `changelog.md`, `contributing.md`, `docs.md` stay at the root.
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,23 @@ threat-intel/
         +-- examples/
             +-- outputs.json                          # one example per persona
 +-- standalone/                                      # flattened single-file distributions
-    +-- cyber-threat-intel-prompt.md                 # self-contained prompt (any LLM)
-    +-- cyber-threat-intel-skill.md                  # self-contained Agent Skill
+|   +-- cyber-threat-intel-prompt.md                # self-contained prompt (any LLM)
+|   +-- cyber-threat-intel-skill.md                 # self-contained Agent Skill
++-- mcp/                                             # threat-intel-mcp server (Phase 1)
+    +-- pyproject.toml                               # package definition (threat-intel-mcp)
+    +-- src/threat_intel_mcp/
+    |   +-- server.py                                # FastMCP stdio server entry point
+    |   +-- normalize.py                             # ioc_network schema validation + dedup
+    |   +-- audit.py                                 # structured audit logging + secret redaction
+    |   +-- adapters/
+    |   |   +-- base.py                              # FetchResult dataclass, SourceAdapter protocol
+    |   |   +-- qfeeds.py                            # Q-Feeds HTTP adapter (paginated, cached)
+    |   +-- vault/
+    |       +-- base.py                              # CredentialProvider protocol
+    |       +-- env.py                               # EnvCredentialProvider (Phase 1: env vars)
+    +-- tests/
+        +-- test_normalize.py                        # schema validation + dedup tests
+        +-- test_qfeeds.py                           # Q-Feeds unit + httpx mock integration tests
 ```
 
 ---
@@ -157,6 +172,37 @@ Full breakdown: [skills/cyber-threat-intel/references/scoring.md](skills/cyber-t
 
 ---
 
+## MCP Server (`mcp/`)
+
+The `mcp/` directory contains `threat-intel-mcp`, an [MCP](https://modelcontextprotocol.io/) server that gives Claude Code live access to threat intelligence feeds. It is the runtime counterpart to the prompt skill — the skill structures the analysis; the MCP server fetches real indicators.
+
+**Phase 1 (current):** Q-Feeds adapter with env-var credentials.
+
+```bash
+cd mcp
+pip install -e .
+QFEEDS_API_KEY=your-key threat-intel-mcp   # stdio transport; wire up in .claude/mcp.json
+```
+
+Configure in Claude Code (`~/.claude/mcp.json` or project `.claude/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "threat-intel": {
+      "command": "threat-intel-mcp",
+      "env": { "QFEEDS_API_KEY": "your-key-here" }
+    }
+  }
+}
+```
+
+Tools exposed: `qfeeds_fetch_iocs`, `list_available_feeds`.
+
+See `mcp/README.md` for full setup, feed types, and planned phases (Vault credentials, additional adapters).
+
+---
+
 ## Output Validation
 
 ```bash
@@ -183,7 +229,7 @@ The skill is built to be driven programmatically (Claude Code, an OpenAI-based p
 
 - **Knowledge cutoff.** Output reflects the model's training data. For breaking threats (last 24-48 hours), consult professional threat intelligence services -- this skill cannot surface intelligence newer than the model behind it.
 - **Illustrative IOCs.** Generated IOCs (IPs, hashes, domains) are examples drawn from known patterns in training data, not real-time indicators. Validate every IOC against trusted feeds before deploying to detection or blocking systems.
-- **No live feeds.** This skill does not integrate with live threat feeds. Sources listed in the Matrix are references the AI draws from based on training data, not API integrations.
+- **No live feeds in the skill itself.** The prompt skill draws from training data, not real-time feeds. For live indicators, use the `mcp/` server with a valid Q-Feeds API key (or a future adapter). Sources listed in the Source Matrix are references, not active API integrations.
 - This skill structures AI output; it does not guarantee accuracy. Always verify critical findings.
 - Detection rules should be tested in a lab environment before production deployment.
 - This is not a replacement for professional threat intelligence services or incident response.

--- a/mcp/src/threat_intel_mcp/server.py
+++ b/mcp/src/threat_intel_mcp/server.py
@@ -9,9 +9,10 @@ Run: threat-intel-mcp   (after `pip install -e .`)
 Requires: QFEEDS_API_KEY environment variable (Phase 1 / dev only).
 """
 
+from __future__ import annotations
+
 import logging
 import sys
-from __future__ import annotations
 
 from typing import Any
 

--- a/mcp/tests/test_normalize.py
+++ b/mcp/tests/test_normalize.py
@@ -1,7 +1,5 @@
 """Tests for the normaliser: schema validation and deduplication."""
 
-import pytest
-
 from threat_intel_mcp.normalize import deduplicate_iocs, validate_iocs
 
 

--- a/mcp/tests/test_qfeeds.py
+++ b/mcp/tests/test_qfeeds.py
@@ -6,11 +6,9 @@ feed type; the adapter's normaliser must produce valid ioc_network objects.
 """
 
 import pytest
-import pytest_asyncio
 from pytest_httpx import HTTPXMock
 
-from threat_intel_mcp.adapters.qfeeds import QFeedsAdapter, _normalize_line, FEED_TYPES
-from threat_intel_mcp.vault.env import EnvCredentialProvider
+from threat_intel_mcp.adapters.qfeeds import QFeedsAdapter, _normalize_line
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **CI: `mcp-tests` job** — runs `pytest tests/ -v` and `ruff check src/ tests/` against the `mcp/` package on every push/PR; previously zero CI coverage on the MCP server
- **CI: feed-integrations consistency step** — cross-checks every feed name in `spec.yaml` `feed_integrations` example against `source-matrix.md` and `original-prompt.md`; catches drift when a new feed is added to one place but not the others
- **README.md** — adds `mcp/` to the repository layout tree; new "MCP Server" section with install/config instructions; updates stale "No live feeds" limitation to reflect the MCP server
- **CLAUDE.md** — documents `mcp/` layout and its relationship to the prompt skill

## Test plan

- [ ] `validate` job passes (all existing checks green)
- [ ] `mcp-tests` job passes (31 tests, ruff clean)
- [ ] Feed-integrations consistency step passes (Q-Feeds found in source-matrix and original-prompt)
- [ ] README `mcp/` tree matches actual directory structure
- [ ] CLAUDE.md Layout section accurately describes all top-level directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ)_