### PR TITLE
Add HashiCorp Vault credential provider and factory (issue #1 Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ credentials.*
 
 # Claude Code runtime state (settings.local.json is tracked; locks are not)
 .claude/*.lock
+# Claude Code agent worktrees (managed by the SDK, not project files)
+.claude/worktrees/

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -22,19 +22,19 @@ threat-intel-mcp  (this repo, stdio MCP server)
 Claude receives ioc_network[], cites "Q-Feeds" in Coverage Ledger (R2/R5)
 ```
 
-## Phase 1 — current state
+## Current state
 
 | Feature | Status |
 |---|---|
-| Q-Feeds REST adapter (malware_ip, malware_domains) | ✅ |
-| Env-var credential provider (dev) | ✅ |
-| Schema validation + deduplication | ✅ |
-| Structured audit logging with redaction | ✅ |
-| MCP tool: `qfeeds_fetch_iocs` | ✅ |
-| MCP tool: `list_available_feeds` | ✅ |
-| pytest suite (no live calls) | ✅ |
-| HashiCorp Vault credential provider | Phase 2 |
-| VirusTotal / Shodan / Recorded Future adapters | Phase 2 |
+| Q-Feeds REST adapter (malware_ip, malware_domains) | ✅ Phase 1 |
+| Env-var credential provider (dev) | ✅ Phase 1 |
+| Schema validation + deduplication | ✅ Phase 1 |
+| Structured audit logging with redaction | ✅ Phase 1 |
+| MCP tool: `qfeeds_fetch_iocs` | ✅ Phase 1 |
+| MCP tool: `list_available_feeds` | ✅ Phase 1 |
+| pytest suite (no live calls) | ✅ Phase 1 |
+| HashiCorp Vault credential provider | ✅ Phase 2 |
+| VirusTotal / Shodan / Recorded Future adapters | Phase 3 |
 | gRPC / MQTT / WebSocket / GraphQL adapters | Phase 3 |
 | Circuit breakers, async fan-out, egress allowlist | Phase 4 |
 
@@ -78,6 +78,59 @@ Add to your Claude Code MCP config (`~/.claude/mcp_servers.json` or `.claude/mcp
 }
 ```
 
+## Vault Credentials (Phase 2)
+
+To use [HashiCorp Vault](https://www.vaultproject.io/) instead of plain environment variables, set the following three variables before starting the server:
+
+```bash
+export VAULT_ADDR=https://vault.example.com:8200
+export VAULT_ROLE_ID=<your-approle-role-id>
+export VAULT_SECRET_ID=<your-approle-secret-id>
+```
+
+When `VAULT_ADDR` is present, `VaultCredentialProvider` is selected automatically; otherwise the server falls back to `EnvCredentialProvider` (env-var mode, dev only).
+
+### Auth method
+
+AppRole is the only supported auth method. Create a role with read-only access to the KV v2 engine and issue a role ID / secret ID pair.
+
+### Secret path structure
+
+Secrets must be stored in KV v2 under:
+
+```
+{mount_point}/data/{adapter_name}/{key}
+```
+
+The default mount point is `secret`. Example for the Q-Feeds API key:
+
+```
+secret/data/qfeeds/api_key
+```
+
+Create it with:
+
+```bash
+vault kv put secret/qfeeds api_key=<your-qfeeds-key>
+```
+
+### Claude Code MCP config (Vault mode)
+
+```json
+{
+  "mcpServers": {
+    "threat-intel-mcp": {
+      "command": "threat-intel-mcp",
+      "env": {
+        "VAULT_ADDR": "https://vault.example.com:8200",
+        "VAULT_ROLE_ID": "your-role-id",
+        "VAULT_SECRET_ID": "your-secret-id"
+      }
+    }
+  }
+}
+```
+
 ### 5. Use with the threat-intel skill
 
 In Claude Code, after the MCP server is connected:
@@ -91,7 +144,7 @@ Claude will call `qfeeds_fetch_iocs`, blend live Q-Feeds IOCs with its training-
 
 ## Security notes
 
-- **Phase 1 only:** `EnvCredentialProvider` reads `QFEEDS_API_KEY` from the environment. This is suitable for local development. Replace with `HashicorpVaultProvider` before deploying.
+- `EnvCredentialProvider` reads `QFEEDS_API_KEY` from the environment. Suitable for local development only — env vars are visible in process listings and container inspection. Use `VaultCredentialProvider` for any non-local deployment (see [Vault Credentials](#vault-credentials-phase-2) above).
 - The API key is used for HTTP Basic auth. It never appears in logs — `audit.py` redacts auth headers and credential-bearing query strings.
 - Upstream responses are schema-validated before being returned to Claude. Malformed IOCs (including any prompt-injection attempt embedded in feed data) are dropped.
 
@@ -101,8 +154,10 @@ Claude will call `qfeeds_fetch_iocs`, blend live Q-Feeds IOCs with its training-
 src/threat_intel_mcp/
 ├── server.py          MCP entrypoint; tool registration
 ├── vault/
-│   ├── base.py        CredentialProvider Protocol
-│   └── env.py         EnvCredentialProvider (dev only)
+│   ├── base.py        CredentialProvider Protocol + CredentialError
+│   ├── env.py         EnvCredentialProvider (dev only)
+│   ├── hashicorp.py   VaultCredentialProvider (AppRole + KV v2)
+│   └── factory.py     credential_provider_from_env() selector
 ├── adapters/
 │   ├── base.py        SourceAdapter Protocol + FetchResult dataclass
 │   └── qfeeds.py      Q-Feeds REST adapter
@@ -110,7 +165,8 @@ src/threat_intel_mcp/
 └── audit.py           Structured logging with secret redaction
 tests/
 ├── test_qfeeds.py     Adapter tests (pytest-httpx, no live calls)
-└── test_normalize.py  Normaliser / validator tests
+├── test_normalize.py  Normaliser / validator tests
+└── test_vault.py      Vault provider + factory tests (hvac mocked)
 ```
 
 ## Relationship to threat-intel

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "threat-intel-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server that delivers live threat intelligence feeds to Claude, normalised to the threat-intel skill schema"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -14,6 +14,7 @@ dependencies = [
     "httpx>=0.27",
     "jsonschema>=4.23",
     "anyio>=4.4",
+    "hvac>=2.0",
 ]
 
 [project.optional-dependencies]
@@ -21,6 +22,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-httpx>=0.30",
+    "pytest-mock>=3.14",
     "vcrpy>=6.0",
     "jsonschema>=4.23",
 ]

--- a/mcp/src/threat_intel_mcp/server.py
+++ b/mcp/src/threat_intel_mcp/server.py
@@ -6,7 +6,8 @@ the threat-intel skill (kj299/threat-intel).
 
 Transport: stdio (for use with Claude Code / Claude Desktop).
 Run: threat-intel-mcp   (after `pip install -e .`)
-Requires: QFEEDS_API_KEY environment variable (Phase 1 / dev only).
+Credentials: set VAULT_ADDR + VAULT_ROLE_ID + VAULT_SECRET_ID for HashiCorp Vault,
+or QFEEDS_API_KEY for env-var mode (dev / local only).
 """
 
 from __future__ import annotations
@@ -20,7 +21,7 @@ from mcp.server.fastmcp import FastMCP
 
 from .adapters.qfeeds import QFeedsAdapter, FEED_TYPES
 from .normalize import deduplicate_iocs, validate_iocs
-from .vault.env import EnvCredentialProvider
+from .vault.factory import credential_provider_from_env
 
 logging.basicConfig(
     level=logging.INFO,
@@ -41,8 +42,8 @@ mcp = FastMCP(
 )
 
 # Initialise the credential provider and adapter at startup.
-# Phase 2 will load the provider type from config (env vs Vault vs AWS SM).
-_credentials = EnvCredentialProvider()
+# Selects VaultCredentialProvider when VAULT_ADDR is set, else EnvCredentialProvider.
+_credentials = credential_provider_from_env()
 _qfeeds = QFeedsAdapter(_credentials)
 
 
@@ -120,10 +121,12 @@ async def list_available_feeds() -> dict[str, Any]:
     Returns each feed's name, tier, supported feed_types, and whether credentials
     are currently configured.
     """
+    from .vault.base import CredentialError
+
     qfeeds_cred_ok = True
     try:
         _credentials.get("qfeeds", "api_key")
-    except KeyError:
+    except (KeyError, CredentialError):
         qfeeds_cred_ok = False
 
     return {
@@ -138,8 +141,8 @@ async def list_available_feeds() -> dict[str, Any]:
                 "tool": "qfeeds_fetch_iocs",
             }
         ],
-        "phase": "1 (MVP — Q-Feeds + env-var credentials)",
-        "planned_phase_2": ["VirusTotal", "Shodan", "Recorded Future", "HashiCorp Vault"],
+        "phase": "2 (Q-Feeds + HashiCorp Vault or env-var credentials)",
+        "planned_phase_3": ["VirusTotal", "Shodan", "Recorded Future"],
     }
 
 

--- a/mcp/src/threat_intel_mcp/vault/__init__.py
+++ b/mcp/src/threat_intel_mcp/vault/__init__.py
@@ -1,4 +1,12 @@
-from .base import CredentialProvider
+from .base import CredentialError, CredentialProvider
 from .env import EnvCredentialProvider
+from .factory import credential_provider_from_env
+from .hashicorp import VaultCredentialProvider
 
-__all__ = ["CredentialProvider", "EnvCredentialProvider"]
+__all__ = [
+    "CredentialError",
+    "CredentialProvider",
+    "EnvCredentialProvider",
+    "VaultCredentialProvider",
+    "credential_provider_from_env",
+]

--- a/mcp/src/threat_intel_mcp/vault/base.py
+++ b/mcp/src/threat_intel_mcp/vault/base.py
@@ -1,4 +1,13 @@
+from __future__ import annotations
+
 from typing import Protocol, runtime_checkable
+
+
+class CredentialError(Exception):
+    """Raised when a credential cannot be retrieved.
+
+    Messages must never contain secret values or tokens.
+    """
 
 
 @runtime_checkable
@@ -6,12 +15,13 @@ class CredentialProvider(Protocol):
     """Retrieves secrets for a named adapter and key.
 
     Implementations must never log, print, or otherwise expose the returned value.
-    Phase 2 will add HashicorpVaultProvider and AwsSecretsManagerProvider.
+    Phase 2 adds HashicorpVaultProvider; Phase 3 will add AwsSecretsManagerProvider.
     """
 
     def get(self, adapter_name: str, key: str) -> str:
         """Return the secret value for (adapter_name, key).
 
-        Raises KeyError if not found.
+        Raises CredentialError if authentication fails or the secret is missing.
+        Raises KeyError if not found (legacy; prefer CredentialError in new impls).
         """
         ...

--- a/mcp/src/threat_intel_mcp/vault/factory.py
+++ b/mcp/src/threat_intel_mcp/vault/factory.py
@@ -1,0 +1,54 @@
+"""Factory for selecting the appropriate CredentialProvider at startup."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from .base import CredentialProvider
+from .env import EnvCredentialProvider
+from .hashicorp import VaultCredentialProvider
+
+logger = logging.getLogger(__name__)
+
+
+def credential_provider_from_env() -> CredentialProvider:
+    """Return the correct CredentialProvider based on environment variables.
+
+    Selection logic:
+    - If ``VAULT_ADDR`` is set: return a ``VaultCredentialProvider`` configured
+      from ``VAULT_ADDR``, ``VAULT_ROLE_ID``, and ``VAULT_SECRET_ID``.
+    - Otherwise: return ``EnvCredentialProvider`` (dev / local mode).
+
+    Raises:
+        RuntimeError: If ``VAULT_ADDR`` is set but ``VAULT_ROLE_ID`` or
+            ``VAULT_SECRET_ID`` are missing.
+    """
+    vault_addr = os.environ.get("VAULT_ADDR")
+
+    if vault_addr:
+        role_id = os.environ.get("VAULT_ROLE_ID")
+        secret_id = os.environ.get("VAULT_SECRET_ID")
+
+        if not role_id:
+            raise RuntimeError(
+                "VAULT_ADDR is set but VAULT_ROLE_ID is missing. "
+                "Set VAULT_ROLE_ID to the AppRole role ID."
+            )
+        if not secret_id:
+            raise RuntimeError(
+                "VAULT_ADDR is set but VAULT_SECRET_ID is missing. "
+                "Set VAULT_SECRET_ID to the AppRole secret ID."
+            )
+
+        logger.info(
+            "Credential provider: VaultCredentialProvider (addr=%s)", vault_addr
+        )
+        return VaultCredentialProvider(
+            vault_addr=vault_addr,
+            role_id=role_id,
+            secret_id=secret_id,
+        )
+
+    logger.info("Credential provider: EnvCredentialProvider (dev mode)")
+    return EnvCredentialProvider()

--- a/mcp/src/threat_intel_mcp/vault/hashicorp.py
+++ b/mcp/src/threat_intel_mcp/vault/hashicorp.py
@@ -1,0 +1,140 @@
+"""HashiCorp Vault credential provider using AppRole auth and KV v2."""
+
+from __future__ import annotations
+
+import logging
+
+import hvac
+import hvac.exceptions
+
+from .base import CredentialError
+
+logger = logging.getLogger(__name__)
+
+
+class VaultCredentialProvider:
+    """Retrieves secrets from HashiCorp Vault using AppRole authentication.
+
+    Authenticates lazily on the first ``get()`` call and caches the token.
+    On a ``Forbidden`` error the provider re-authenticates once before raising.
+
+    Secret path convention: ``{mount_point}/data/{adapter_name}/{key}``
+    Example: ``secret/data/qfeeds/api_key``
+
+    The secret value is never logged.
+    """
+
+    def __init__(
+        self,
+        vault_addr: str,
+        role_id: str,
+        secret_id: str,
+        mount_point: str = "secret",
+    ) -> None:
+        self._vault_addr = vault_addr
+        self._role_id = role_id
+        self._secret_id = secret_id
+        self._mount_point = mount_point
+        self._client: hvac.Client | None = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _authenticate(self) -> None:
+        """Perform AppRole login and store the authenticated client."""
+        client = hvac.Client(url=self._vault_addr)
+        try:
+            result = client.auth.approle.login(
+                role_id=self._role_id,
+                secret_id=self._secret_id,
+            )
+        except Exception as exc:
+            # Do not include exc details — they may contain secret_id fragments.
+            raise CredentialError(
+                "Vault AppRole authentication failed. "
+                "Check VAULT_ADDR, VAULT_ROLE_ID, and VAULT_SECRET_ID."
+            ) from exc
+
+        if not result or not client.is_authenticated():
+            raise CredentialError(
+                "Vault AppRole login returned an invalid token. "
+                "Verify the role_id and secret_id are correct."
+            )
+
+        self._client = client
+        logger.debug("Vault AppRole authentication successful.")
+
+    def _read_secret(self, adapter_name: str, key: str) -> str:
+        """Read a single secret value from the KV v2 engine."""
+        assert self._client is not None  # guaranteed by callers
+        path = f"{adapter_name}/{key}"
+        try:
+            response = self._client.secrets.kv.v2.read_secret_version(
+                path=path,
+                mount_point=self._mount_point,
+            )
+        except hvac.exceptions.Forbidden:
+            # Let Forbidden propagate so get() can attempt token renewal.
+            raise
+        except hvac.exceptions.InvalidPath:
+            raise CredentialError(
+                f"Secret not found at path '{self._mount_point}/data/{path}'. "
+                "Ensure the secret exists in Vault."
+            )
+        except Exception as exc:
+            raise CredentialError(
+                f"Failed to read secret '{self._mount_point}/data/{path}' from Vault."
+            ) from exc
+
+        try:
+            value = response["data"]["data"][key]
+        except (KeyError, TypeError):
+            raise CredentialError(
+                f"Key '{key}' not present in Vault secret at "
+                f"'{self._mount_point}/data/{path}'."
+            )
+
+        if value is None:
+            raise CredentialError(
+                f"Key '{key}' exists but has a null value at "
+                f"'{self._mount_point}/data/{path}'."
+            )
+
+        return str(value)
+
+    # ------------------------------------------------------------------
+    # CredentialProvider protocol
+    # ------------------------------------------------------------------
+
+    def get(self, adapter_name: str, key: str) -> str:
+        """Return the secret value for ``(adapter_name, key)`` from Vault.
+
+        Reads from ``{mount_point}/data/{adapter_name}/{key}``.
+
+        Raises:
+            CredentialError: If authentication fails or the secret is absent.
+        """
+        # Lazy authentication on first call.
+        if self._client is None:
+            self._authenticate()
+
+        logger.debug(
+            "Fetching Vault secret: adapter=%s key=%s mount=%s",
+            adapter_name,
+            key,
+            self._mount_point,
+        )
+
+        try:
+            return self._read_secret(adapter_name, key)
+        except hvac.exceptions.Forbidden:
+            # Token may have expired; re-authenticate once.
+            logger.debug(
+                "Vault token forbidden for adapter=%s key=%s — re-authenticating.",
+                adapter_name,
+                key,
+            )
+            self._client = None
+            self._authenticate()
+            return self._read_secret(adapter_name, key)

--- a/mcp/tests/test_vault.py
+++ b/mcp/tests/test_vault.py
@@ -1,0 +1,163 @@
+"""Tests for the vault credential providers and factory.
+
+No live Vault server required — hvac.Client is mocked throughout.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from threat_intel_mcp.vault.base import CredentialError
+from threat_intel_mcp.vault.env import EnvCredentialProvider
+from threat_intel_mcp.vault.factory import credential_provider_from_env
+from threat_intel_mcp.vault.hashicorp import VaultCredentialProvider
+
+
+# ---------------------------------------------------------------------------
+# Factory tests
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialProviderFromEnv:
+    def test_env_provider_selected_when_no_vault_addr(self, monkeypatch):
+        monkeypatch.delenv("VAULT_ADDR", raising=False)
+        provider = credential_provider_from_env()
+        assert isinstance(provider, EnvCredentialProvider)
+
+    def test_vault_provider_selected_when_vault_addr_set(self, monkeypatch):
+        monkeypatch.setenv("VAULT_ADDR", "https://vault.example.com:8200")
+        monkeypatch.setenv("VAULT_ROLE_ID", "test-role-id")
+        monkeypatch.setenv("VAULT_SECRET_ID", "test-secret-id")
+        provider = credential_provider_from_env()
+        assert isinstance(provider, VaultCredentialProvider)
+
+    def test_vault_provider_missing_role_id_raises(self, monkeypatch):
+        monkeypatch.setenv("VAULT_ADDR", "https://vault.example.com:8200")
+        monkeypatch.delenv("VAULT_ROLE_ID", raising=False)
+        monkeypatch.setenv("VAULT_SECRET_ID", "test-secret-id")
+        with pytest.raises(RuntimeError, match="VAULT_ROLE_ID"):
+            credential_provider_from_env()
+
+    def test_vault_provider_missing_secret_id_raises(self, monkeypatch):
+        monkeypatch.setenv("VAULT_ADDR", "https://vault.example.com:8200")
+        monkeypatch.setenv("VAULT_ROLE_ID", "test-role-id")
+        monkeypatch.delenv("VAULT_SECRET_ID", raising=False)
+        with pytest.raises(RuntimeError, match="VAULT_SECRET_ID"):
+            credential_provider_from_env()
+
+
+# ---------------------------------------------------------------------------
+# VaultCredentialProvider unit tests (hvac mocked)
+# ---------------------------------------------------------------------------
+
+
+def _make_kv2_response(key: str, value: str) -> dict:
+    """Build a minimal hvac KV v2 read_secret_version response."""
+    return {"data": {"data": {key: value}}}
+
+
+class TestVaultCredentialProvider:
+    def test_vault_get_fetches_kv2_secret(self, mocker):
+        mock_client_cls = mocker.patch("threat_intel_mcp.vault.hashicorp.hvac.Client")
+        mock_client = mock_client_cls.return_value
+        mock_client.is_authenticated.return_value = True
+        mock_client.auth.approle.login.return_value = {"auth": {"client_token": "tok"}}
+        mock_client.secrets.kv.v2.read_secret_version.return_value = (
+            _make_kv2_response("api_key", "super-secret-value")
+        )
+
+        provider = VaultCredentialProvider(
+            vault_addr="https://vault.example.com:8200",
+            role_id="role-id",
+            secret_id="secret-id",
+        )
+        result = provider.get("qfeeds", "api_key")
+
+        assert result == "super-secret-value"
+        mock_client.auth.approle.login.assert_called_once_with(
+            role_id="role-id",
+            secret_id="secret-id",
+        )
+        mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
+            path="qfeeds/api_key",
+            mount_point="secret",
+        )
+
+    def test_vault_get_reraises_credential_error_on_missing_secret(self, mocker):
+        import hvac.exceptions
+
+        mock_client_cls = mocker.patch("threat_intel_mcp.vault.hashicorp.hvac.Client")
+        mock_client = mock_client_cls.return_value
+        mock_client.is_authenticated.return_value = True
+        mock_client.auth.approle.login.return_value = {"auth": {"client_token": "tok"}}
+        mock_client.secrets.kv.v2.read_secret_version.side_effect = (
+            hvac.exceptions.InvalidPath("not found")
+        )
+
+        provider = VaultCredentialProvider(
+            vault_addr="https://vault.example.com:8200",
+            role_id="role-id",
+            secret_id="secret-id",
+        )
+        with pytest.raises(CredentialError, match="not found"):
+            provider.get("qfeeds", "api_key")
+
+    def test_vault_token_renewal_on_forbidden(self, mocker):
+        import hvac.exceptions
+
+        mock_client_cls = mocker.patch("threat_intel_mcp.vault.hashicorp.hvac.Client")
+        mock_client = mock_client_cls.return_value
+        mock_client.is_authenticated.return_value = True
+        mock_client.auth.approle.login.return_value = {"auth": {"client_token": "tok"}}
+
+        # First read raises Forbidden; second read (after re-auth) succeeds.
+        mock_client.secrets.kv.v2.read_secret_version.side_effect = [
+            hvac.exceptions.Forbidden("token expired"),
+            _make_kv2_response("api_key", "renewed-value"),
+        ]
+
+        provider = VaultCredentialProvider(
+            vault_addr="https://vault.example.com:8200",
+            role_id="role-id",
+            secret_id="secret-id",
+        )
+        result = provider.get("qfeeds", "api_key")
+
+        assert result == "renewed-value"
+        # Should have authenticated twice (initial + renewal).
+        assert mock_client.auth.approle.login.call_count == 2
+
+    def test_vault_auth_failure_raises_credential_error(self, mocker):
+        mock_client_cls = mocker.patch("threat_intel_mcp.vault.hashicorp.hvac.Client")
+        mock_client = mock_client_cls.return_value
+        mock_client.auth.approle.login.side_effect = Exception("connection refused")
+
+        provider = VaultCredentialProvider(
+            vault_addr="https://vault.example.com:8200",
+            role_id="bad-role",
+            secret_id="bad-secret",
+        )
+        with pytest.raises(CredentialError, match="authentication failed"):
+            provider.get("qfeeds", "api_key")
+
+    def test_vault_secret_value_not_in_exception_message(self, mocker):
+        """Ensure secret values never appear in CredentialError messages."""
+        mock_client_cls = mocker.patch("threat_intel_mcp.vault.hashicorp.hvac.Client")
+        mock_client = mock_client_cls.return_value
+        mock_client.is_authenticated.return_value = True
+        mock_client.auth.approle.login.return_value = {"auth": {"client_token": "tok"}}
+        mock_client.secrets.kv.v2.read_secret_version.return_value = {
+            "data": {"data": {}}  # key missing
+        }
+
+        provider = VaultCredentialProvider(
+            vault_addr="https://vault.example.com:8200",
+            role_id="role-id",
+            secret_id="secret-id",
+        )
+        with pytest.raises(CredentialError) as exc_info:
+            provider.get("qfeeds", "api_key")
+
+        # Verify the secret_id does not appear in the error message.
+        assert "secret-id" not in str(exc_info.value)
+        assert "role-id" not in str(exc_info.value)


### PR DESCRIPTION
## Summary

- **`VaultCredentialProvider`** (`mcp/src/threat_intel_mcp/vault/hashicorp.py`): implements the `CredentialProvider` protocol using `hvac` with AppRole auth and the KV v2 secrets engine. Authenticates lazily on first `get()` call; on a `Forbidden` error re-authenticates once before raising. Secret values are never logged. Raises `CredentialError` (not `ValueError`) on auth failure or missing secret, with safe messages that contain no credential fragments.
- **`CredentialError`** added to `vault/base.py`: a proper exception class for all credential-retrieval failures across providers.
- **`credential_provider_from_env()`** factory (`mcp/src/threat_intel_mcp/vault/factory.py`): reads `VAULT_ADDR` at startup; if set, constructs `VaultCredentialProvider` from `VAULT_ROLE_ID` / `VAULT_SECRET_ID` (raises `RuntimeError` if either is missing); otherwise falls back to `EnvCredentialProvider`. Logs which provider was selected at INFO level (no credential values logged).
- **`server.py`** updated to call the factory instead of hardcoding `EnvCredentialProvider`. `list_available_feeds` now catches both `KeyError` and `CredentialError` when probing credential availability.
- **`mcp/tests/test_vault.py`**: 9 unit tests covering factory selection, missing-env-var errors, KV v2 secret fetch, missing-secret `CredentialError`, token renewal on `Forbidden`, auth failure, and secret-value-not-in-exception-message safety check. All use `pytest-mock` to mock `hvac.Client` — no live Vault required.
- **`mcp/pyproject.toml`**: version bumped to `0.2.0`, `hvac>=2.0` added to `dependencies`, `pytest-mock>=3.14` added to `dev` optional deps.
- **`mcp/README.md`**: new "Vault Credentials (Phase 2)" section covering env vars, AppRole auth, KV v2 path structure (`secret/data/{adapter_name}/{key}`), `vault kv put` example, and Claude Code MCP config snippet.

## Test plan

- [ ] `cd mcp && pip install -e ".[dev]"` installs cleanly (includes `hvac` and `pytest-mock`)
- [ ] `python -m pytest tests/ -v` → 40 passed, 0 failed (31 existing + 9 new vault tests)
- [ ] `ruff check src/ tests/` → all checks passed
- [ ] With `VAULT_ADDR` unset: server starts with `EnvCredentialProvider` (warning logged)
- [ ] With `VAULT_ADDR` set but `VAULT_ROLE_ID` missing: server raises `RuntimeError` at startup
- [ ] With all three Vault env vars set: server starts with `VaultCredentialProvider` (INFO logged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ)_