### PR TITLE
Add AlienVault OTX feed adapter (M3a)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,10 +12,10 @@ flowchart TD
     end
 
     subgraph MCP["threat-intel-mcp (stdio transport)"]
-        Server["MCP Server\nserver.py\ntools: qfeeds_fetch_iocs\n       abuseipdb_fetch_blocklist\n       virustotal_fetch_iocs"]
+        Server["MCP Server\nserver.py\ntools: qfeeds_fetch_iocs\n       abuseipdb_fetch_blocklist\n       virustotal_fetch_iocs\n       otx_fetch_iocs"]
 
         subgraph Cred["CredentialProvider"]
-            EnvCred["Phase 1: EnvCredentialProvider\nreads QFEEDS_API_KEY\nreads ABUSEIPDB_API_KEY\nreads VT_API_KEY"]
+            EnvCred["Phase 1: EnvCredentialProvider\nreads QFEEDS_API_KEY\nreads ABUSEIPDB_API_KEY\nreads VT_API_KEY\nreads OTX_API_KEY"]
             VaultCred["Phase 2: VaultCredentialProvider\nreads from HashiCorp Vault"]
         end
 
@@ -23,7 +23,7 @@ flowchart TD
             QFeeds["QFeedsAdapter\nadapters/qfeeds.py\nHTTP Basic auth\n20-min cache"]
             AbuseIPDB["AbuseIPDBAdapter\nadapters/abuseipdb.py\nHeader Key auth\n60-min cache"]
             VT["VirusTotalAdapter\nadapters/virustotal.py\nx-apikey header\n15-min cache\n15s rate limit"]
-            OTX["AlienVault OTX\n(planned)"]
+            OTX["OTXAdapter\nadapters/otx.py\nX-OTX-API-KEY header\n60-min cache"]
         end
 
         Normalize["normalize.py\nvalidate_iocs + deduplicate_iocs\nioc_network schema"]
@@ -34,7 +34,7 @@ flowchart TD
         QFeedsAPI["Q-Feeds API\nhttps://api.qfeeds.com/api\npaginated · malware_ip · malware_domains"]
         AbuseIPDB_API["AbuseIPDB API\nhttps://api.abuseipdb.com/api/v2/blacklist\nsingle request · up to 10,000 IPs"]
         VT_API["VirusTotal API v3\nhttps://www.virustotal.com/api/v3\nfeeds/malicious_ips · feeds/malicious_domains\nnewline-delimited JSON"]
-        OTX_API["AlienVault OTX API\n(planned)"]:::planned
+        OTX_API["AlienVault OTX API\nhttps://otx.alienvault.com/api/v1\nGET /pulses/subscribed · paginated"]
     end
 
     User -->|"invokes skill"| Skill
@@ -44,29 +44,28 @@ flowchart TD
     EnvCred -->|"api_key"| QFeeds
     EnvCred -->|"api_key"| AbuseIPDB
     EnvCred -->|"api_key"| VT
+    EnvCred -->|"api_key"| OTX
     VaultCred -.->|"api_key (Phase 2)"| QFeeds
     VaultCred -.->|"api_key (Phase 2)"| AbuseIPDB
     VaultCred -.->|"api_key (Phase 2)"| VT
+    VaultCred -.->|"api_key (Phase 2)"| OTX
     QFeeds -->|"GET /api?feed_type=..&page=N"| QFeedsAPI
     QFeedsAPI -->|"plain-text indicators"| QFeeds
     AbuseIPDB -->|"GET /blacklist?confidenceMinimum=90"| AbuseIPDB_API
     AbuseIPDB_API -->|"JSON IP entries"| AbuseIPDB
     VT -->|"GET /feeds/{feed_type}?cursor=..&limit=40"| VT_API
     VT_API -->|"newline-delimited JSON"| VT
+    OTX -->|"GET /pulses/subscribed?modified_since=.."| OTX_API
+    OTX_API -->|"JSON pulses + indicators"| OTX
     QFeeds -->|"raw ioc_network objects"| Normalize
     AbuseIPDB -->|"raw ioc_network objects"| Normalize
     VT -->|"raw ioc_network objects"| Normalize
+    OTX -->|"raw ioc_network objects"| Normalize
     Normalize -->|"validated + deduped IOCs"| FetchResult
     FetchResult -->|"iocs · coverage_ledger_entry"| Server
     Server -->|"FetchResult dict"| Skill
-    Skill -->|"cites as source: Q-Feeds / AbuseIPDB / VirusTotal (live)\nincorporates IOCs into report"| Output
+    Skill -->|"cites sources: Q-Feeds / AbuseIPDB / VirusTotal / OTX (live)\nincorporates IOCs into report"| Output
     Output -->|"validated JSON"| User
-
-    Server -.->|"planned"| OTX
-    OTX -.->|"planned"| OTX_API
-
-    classDef planned stroke-dasharray:6 4,fill:#f9f9f9,color:#888
-    class OTX,OTX_API planned
 ```
 
 ## Component Notes
@@ -74,14 +73,13 @@ flowchart TD
 | Component | File | Role |
 |-----------|------|------|
 | Skill | `skills/cyber-threat-intel/SKILL.md` | Entrypoint; guides analysis workflow and report structure |
-| MCP Server | `mcp/src/threat_intel_mcp/server.py` | FastMCP stdio server; exposes `qfeeds_fetch_iocs`, `abuseipdb_fetch_blocklist`, `virustotal_fetch_iocs`, and `list_available_feeds` |
-| EnvCredentialProvider | `mcp/src/threat_intel_mcp/vault/env.py` | Phase 1: reads `QFEEDS_API_KEY`, `ABUSEIPDB_API_KEY`, and `VT_API_KEY` from environment |
+| MCP Server | `mcp/src/threat_intel_mcp/server.py` | FastMCP stdio server; exposes `qfeeds_fetch_iocs`, `abuseipdb_fetch_blocklist`, `virustotal_fetch_iocs`, `otx_fetch_iocs`, and `list_available_feeds` |
+| EnvCredentialProvider | `mcp/src/threat_intel_mcp/vault/env.py` | Phase 1: reads `QFEEDS_API_KEY`, `ABUSEIPDB_API_KEY`, `VT_API_KEY`, and `OTX_API_KEY` from environment |
 | VaultCredentialProvider | `mcp/src/threat_intel_mcp/vault/` | Phase 2: reads credentials from HashiCorp Vault |
 | QFeedsAdapter | `mcp/src/threat_intel_mcp/adapters/qfeeds.py` | Fetches paginated malware IP and domain feeds; 20-min in-process cache |
 | AbuseIPDBAdapter | `mcp/src/threat_intel_mcp/adapters/abuseipdb.py` | Fetches IP blacklist (up to 10,000 IPs, confidenceMinimum=90); 60-min in-process cache |
 | VirusTotalAdapter | `mcp/src/threat_intel_mcp/adapters/virustotal.py` | Fetches recent malicious IPs and domains from VT Intelligence feeds; 15-min cache; 15s inter-request rate limit |
+| OTXAdapter | `mcp/src/threat_intel_mcp/adapters/otx.py` | Fetches subscribed OTX pulses (IPv4, IPv6, Domain, URL); 60-min in-process cache |
 | normalize.py | `mcp/src/threat_intel_mcp/normalize.py` | Validates `ioc_network` objects against inline schema; deduplicates by `(type, value)` |
 | FetchResult | `mcp/src/threat_intel_mcp/adapters/base.py` | Dataclass: `iocs`, `source`, `tier`, `record_count`, `retrieved_at`, `latency_ms` |
 | Output schema | `skills/cyber-threat-intel/schemas/output.schema.json` | JSON Schema the final report is validated against |
-
-Dashed boxes and dashed arrows indicate components planned for a future phase but not yet implemented.

--- a/mcp/src/threat_intel_mcp/adapters/otx.py
+++ b/mcp/src/threat_intel_mcp/adapters/otx.py
@@ -1,0 +1,264 @@
+"""AlienVault OTX feed adapter.
+
+Fetches threat indicators from subscribed OTX pulses via the OTX REST API
+(https://otx.alienvault.com/api/v1) and normalises them to ioc_network objects
+compatible with output.schema.json from kj299/threat-intel.
+
+Authentication: HTTP header X-OTX-API-KEY.
+Credentials are sourced exclusively from the injected CredentialProvider.
+  credentials.get("otx", "api_key") -> env var OTX_API_KEY
+
+API characteristics (as of 2026):
+  - Endpoint: GET /pulses/subscribed?limit=20&page=1&modified_since=<ISO8601>
+  - Response: JSON {"results": [...pulses...], "next": "url or null"}
+  - Each pulse has an "indicators" list
+  - Update frequency: hourly -> cache TTL 3600 seconds
+  - Max pages per fetch: 10 (to bound latency)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+
+from ..audit import log_tool_call, redact_url
+from ..vault.base import CredentialProvider
+from .base import FetchResult
+
+logger = logging.getLogger(__name__)
+
+_API_BASE = "https://otx.alienvault.com/api/v1"
+
+# OTX updates hourly; cache for one hour.
+CACHE_TTL_SECONDS = 3600
+
+# Hard limit on pagination to bound latency and memory.
+MAX_PAGES = 10
+
+# Default page size for subscribed pulses endpoint.
+PAGE_SIZE = 20
+
+# OTX indicator type -> ioc_network type mapping.
+# Types not present here are skipped (e.g. file hashes are not in ioc_network schema).
+_TYPE_MAP: dict[str, str] = {
+    "IPv4": "IPv4",
+    "IPv6": "IPv6",
+    "domain": "Domain",
+    "hostname": "Domain",
+    "URL": "URL",
+}
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _pulse_name_slug(name: str) -> str:
+    """Convert a pulse name to a lowercase hyphen-separated slug for use in tags."""
+    return _SLUG_RE.sub("-", name.lower()).strip("-")
+
+
+def _normalize_indicator(ind: dict[str, Any], *, pulse_name: str = "") -> dict[str, Any] | None:
+    """Map a single OTX indicator dict to an ioc_network dict, or None if unsupported.
+
+    Args:
+        ind: A single indicator object from the OTX pulse indicators list.
+        pulse_name: The name of the enclosing pulse, used to generate tags.
+
+    Returns:
+        An ioc_network-shaped dict, or None for unsupported indicator types.
+    """
+    otx_type = ind.get("type", "")
+    ioc_type = _TYPE_MAP.get(otx_type)
+    if ioc_type is None:
+        logger.debug("Skipping unsupported OTX indicator type: %r", otx_type)
+        return None
+
+    value = ind.get("indicator", "")
+    if not value:
+        logger.debug("Skipping OTX indicator with empty value: %r", ind)
+        return None
+
+    tags = ["otx"]
+    if pulse_name:
+        slug = _pulse_name_slug(pulse_name)
+        if slug:
+            tags.append(slug)
+
+    result: dict[str, Any] = {
+        "type": ioc_type,
+        "value": value,
+        "confidence": "High",
+        "source": "AlienVault OTX",
+        "action": "alert",
+        "tlp": "WHITE",
+        "tags": tags,
+    }
+
+    # Include first_seen from "created" if present and non-empty.
+    created = ind.get("created", "")
+    if created:
+        result["first_seen"] = created
+
+    return result
+
+
+def _parse_time_range(time_range: str) -> datetime:
+    """Parse a time_range string like '7d' or '24h' and return the start datetime."""
+    time_range = time_range.strip().lower()
+    now = datetime.now(timezone.utc)
+
+    if time_range.endswith("d"):
+        days = int(time_range[:-1])
+        return now - timedelta(days=days)
+    if time_range.endswith("h"):
+        hours = int(time_range[:-1])
+        return now - timedelta(hours=hours)
+    if time_range.endswith("m"):
+        minutes = int(time_range[:-1])
+        return now - timedelta(minutes=minutes)
+
+    raise ValueError(
+        f"Unrecognised time_range format: {time_range!r}. "
+        "Expected format like '7d', '24h', or '30m'."
+    )
+
+
+class OTXAdapter:
+    """Adapter for AlienVault OTX subscribed-pulse feed."""
+
+    name = "AlienVault OTX"
+    tier = 2
+
+    def __init__(self, credentials: CredentialProvider) -> None:
+        self._credentials = credentials
+        # In-process cache keyed by "otx_subscribed".
+        self._cache: dict[str, tuple[list[dict[str, Any]], float]] = {}
+
+    def _make_client(self) -> httpx.AsyncClient:
+        api_key = self._credentials.get("otx", "api_key")
+        return httpx.AsyncClient(
+            headers={
+                "X-OTX-API-KEY": api_key,
+                "User-Agent": "threat-intel-mcp/0.3 (kj299/threat-intel)",
+            },
+            timeout=httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=5.0),
+        )
+
+    async def fetch(
+        self,
+        *,
+        time_range: str = "7d",
+        feed_types: list[str] | None = None,
+    ) -> FetchResult:
+        """Fetch indicators from OTX subscribed pulses modified within time_range.
+
+        Args:
+            time_range: Lookback window, e.g. "7d" or "24h".
+            feed_types: Accepted for interface compatibility; OTX does not use this.
+
+        Returns:
+            FetchResult with normalised ioc_network objects.
+        """
+        t_start = time.monotonic()
+        failed: list[str] = []
+
+        since_dt = _parse_time_range(time_range)
+        since_iso = since_dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+        try:
+            async with self._make_client() as client:
+                iocs = await self._fetch_subscribed(client, since_iso)
+        except Exception as exc:
+            logger.warning("OTX fetch failed: %s", exc)
+            failed.append("subscribed")
+            iocs = []
+
+        latency_ms = (time.monotonic() - t_start) * 1000
+
+        log_tool_call(
+            "otx_fetch_iocs",
+            {"time_range": time_range, "modified_since": since_iso},
+            record_count=len(iocs),
+            latency_ms=latency_ms,
+            status="partial" if failed else "ok",
+            error=f"failed: {failed}" if failed else None,
+        )
+
+        return FetchResult(
+            iocs=iocs,
+            source="AlienVault OTX",
+            tier=2,
+            retrieved_at=datetime.now(timezone.utc).isoformat(),
+            record_count=len(iocs),
+            latency_ms=round(latency_ms, 1),
+            feed_types_fetched=[] if failed else ["subscribed"],
+            partial_failure=failed,
+        )
+
+    async def _fetch_subscribed(
+        self, client: httpx.AsyncClient, since_iso: str
+    ) -> list[dict[str, Any]]:
+        """Fetch all pages of subscribed pulses, using the in-process cache.
+
+        Args:
+            client: Authenticated httpx.AsyncClient.
+            since_iso: ISO 8601 datetime string for modified_since filter.
+
+        Returns:
+            List of normalised ioc_network dicts.
+        """
+        cache_key = "otx_subscribed"
+        now = time.monotonic()
+
+        if cache_key in self._cache:
+            cached_iocs, expiry = self._cache[cache_key]
+            if now < expiry:
+                logger.debug(
+                    "OTX cache hit: records=%d", len(cached_iocs)
+                )
+                return cached_iocs
+
+        iocs: list[dict[str, Any]] = []
+        base_url = f"{_API_BASE}/pulses/subscribed"
+        first_params = {"limit": PAGE_SIZE, "page": 1, "modified_since": since_iso}
+        # next_url is None on the first iteration; we use first_params then.
+        next_url: str | None = None
+        pages_fetched = 0
+
+        while pages_fetched < MAX_PAGES:
+            if next_url is not None:
+                logger.info("OTX request: url=%s", redact_url(next_url))
+                resp = await client.get(next_url)
+            else:
+                logger.info("OTX request: url=%s", redact_url(base_url))
+                resp = await client.get(base_url, params=first_params)
+            resp.raise_for_status()
+            pages_fetched += 1
+
+            data = resp.json()
+            pulses = data.get("results", [])
+
+            for pulse in pulses:
+                pulse_name = pulse.get("name", "")
+                for ind in pulse.get("indicators", []):
+                    normalised = _normalize_indicator(ind, pulse_name=pulse_name)
+                    if normalised is not None:
+                        iocs.append(normalised)
+
+            next_url = data.get("next") or None
+            if next_url is None:
+                break
+
+        if pages_fetched >= MAX_PAGES and next_url:
+            logger.warning(
+                "OTX pagination limit reached (%d pages); some pulses may be omitted.",
+                MAX_PAGES,
+            )
+
+        self._cache[cache_key] = (iocs, now + CACHE_TTL_SECONDS)
+        logger.info("OTX cached: records=%d pages=%d", len(iocs), pages_fetched)
+        return iocs

--- a/mcp/src/threat_intel_mcp/server.py
+++ b/mcp/src/threat_intel_mcp/server.py
@@ -1,13 +1,13 @@
 """threat-intel-mcp: MCP server for live threat intelligence feed integration.
 
-Exposes Q-Feeds, AbuseIPDB, VirusTotal (and future adapters) as MCP tools that
+Exposes Q-Feeds, AbuseIPDB, VirusTotal, and AlienVault OTX as MCP tools that
 Claude can call to retrieve live IOCs and incorporate them into threat intelligence
 reports using the threat-intel skill (kj299/threat-intel).
 
 Transport: stdio (for use with Claude Code / Claude Desktop).
 Run: threat-intel-mcp   (after `pip install -e .`)
 Credentials: set VAULT_ADDR + VAULT_ROLE_ID + VAULT_SECRET_ID for HashiCorp Vault,
-or QFEEDS_API_KEY / ABUSEIPDB_API_KEY / VT_API_KEY for env-var mode (dev / local only).
+or QFEEDS_API_KEY / ABUSEIPDB_API_KEY / VT_API_KEY / OTX_API_KEY for env-var mode.
 """
 
 from __future__ import annotations
@@ -20,6 +20,7 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 
 from .adapters.abuseipdb import AbuseIPDBAdapter
+from .adapters.otx import OTXAdapter
 from .adapters.qfeeds import QFeedsAdapter, FEED_TYPES as QFEEDS_FEED_TYPES
 from .adapters.virustotal import VirusTotalAdapter, FEED_TYPES as VT_FEED_TYPES
 from .normalize import deduplicate_iocs, validate_iocs
@@ -37,7 +38,8 @@ mcp = FastMCP(
     "threat-intel-mcp",
     instructions=(
         "Live threat intelligence feed tools. Call these to retrieve current IOCs "
-        "from subscribed commercial feeds (Q-Feeds Tier 2, AbuseIPDB Tier 3, VirusTotal Tier 2). "
+        "from subscribed commercial feeds (Q-Feeds Tier 2, AbuseIPDB Tier 3, "
+        "VirusTotal Tier 2, AlienVault OTX Tier 2). "
         "After calling a feed tool, pass the returned iocs array as context and set "
         "skill_input.feed_integrations in the threat-intel skill output so the "
         "Coverage Ledger (Appendix A) correctly marks the source as consulted."
@@ -50,6 +52,7 @@ _credentials = credential_provider_from_env()
 _qfeeds = QFeedsAdapter(_credentials)
 _abuseipdb = AbuseIPDBAdapter(_credentials)
 _virustotal = VirusTotalAdapter(_credentials)
+_otx = OTXAdapter(_credentials)
 
 
 @mcp.tool()
@@ -252,6 +255,78 @@ async def virustotal_fetch_iocs(
 
 
 @mcp.tool()
+async def otx_fetch_iocs(
+    time_range: str = "7d",
+    feed_types: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fetch threat indicators from AlienVault OTX subscribed pulses (Tier 2 CTI).
+
+    Retrieves indicators from pulses modified within the given time_range,
+    returning ioc_network objects in the threat-intel output.schema.json shape.
+    De-duplicated and schema-validated before return.
+
+    Args:
+        time_range: Lookback window, e.g. "7d" or "24h". OTX is queried with
+            modified_since = now - time_range.
+        feed_types: Accepted for interface compatibility; OTX does not segment
+            by feed type. Pass None or omit.
+
+    Returns:
+        dict with keys: iocs, source, tier, retrieved_at, record_count,
+        latency_ms, feed_types_fetched, partial_failure, coverage_ledger_entry.
+
+    Usage with the threat-intel skill:
+        1. Call this tool; receive iocs.
+        2. Pass iocs as context to the skill invocation.
+        3. Set skill_input.feed_integrations = [{"name": "AlienVault OTX", "tier": 2,
+           "access_level": "community"}] so the Coverage Ledger marks it consulted.
+    """
+    try:
+        result = await _otx.fetch(time_range=time_range, feed_types=feed_types)
+    except (CredentialError, KeyError) as exc:
+        logger.warning("OTX credential error: %s", exc)
+        return {
+            "iocs": [],
+            "source": "AlienVault OTX",
+            "tier": 2,
+            "retrieved_at": "",
+            "record_count": 0,
+            "latency_ms": 0.0,
+            "feed_types_fetched": [],
+            "partial_failure": ["subscribed"],
+            "coverage_ledger_entry": {
+                "tier": 2,
+                "source": "AlienVault OTX",
+                "status": "unverified",
+            },
+            "error": "OTX credentials not configured. Set OTX_API_KEY environment variable.",
+        }
+
+    validated = validate_iocs(result.iocs)
+    deduped = deduplicate_iocs(validated)
+
+    status = "consulted"
+    if result.partial_failure:
+        status = "partial" if deduped else "unverified"
+
+    return {
+        "iocs": deduped,
+        "source": result.source,
+        "tier": result.tier,
+        "retrieved_at": result.retrieved_at,
+        "record_count": len(deduped),
+        "latency_ms": result.latency_ms,
+        "feed_types_fetched": result.feed_types_fetched,
+        "partial_failure": result.partial_failure,
+        "coverage_ledger_entry": {
+            "tier": 2,
+            "source": "AlienVault OTX",
+            "status": status,
+        },
+    }
+
+
+@mcp.tool()
 async def list_available_feeds() -> dict[str, Any]:
     """List the threat intelligence feeds available in this MCP server instance.
 
@@ -275,6 +350,12 @@ async def list_available_feeds() -> dict[str, Any]:
         _credentials.get("virustotal", "api_key")
     except (KeyError, CredentialError):
         vt_cred_ok = False
+
+    otx_cred_ok = True
+    try:
+        _credentials.get("otx", "api_key")
+    except (KeyError, CredentialError):
+        otx_cred_ok = False
 
     return {
         "feeds": [
@@ -305,9 +386,18 @@ async def list_available_feeds() -> dict[str, Any]:
                 "credential_configured": vt_cred_ok,
                 "tool": "virustotal_fetch_iocs",
             },
+            {
+                "name": "AlienVault OTX",
+                "tier": 2,
+                "domain": "otx.alienvault.com",
+                "description": "Community and commercial threat pulses with IP, domain, and URL indicators",
+                "feed_types": ["subscribed"],
+                "credential_configured": otx_cred_ok,
+                "tool": "otx_fetch_iocs",
+            },
         ],
-        "phase": "3 (Q-Feeds + AbuseIPDB + VirusTotal + HashiCorp Vault or env-var credentials)",
-        "planned": ["AlienVault OTX", "Shodan", "Recorded Future"],
+        "phase": "3 (Q-Feeds + AbuseIPDB + VirusTotal + AlienVault OTX + HashiCorp Vault or env-var credentials)",
+        "planned": ["Shodan", "Recorded Future"],
     }
 
 

--- a/mcp/tests/test_otx.py
+++ b/mcp/tests/test_otx.py
@@ -1,0 +1,311 @@
+"""Tests for the AlienVault OTX adapter.
+
+Uses pytest-httpx to intercept HTTP calls — no live network access in CI.
+Each test provides a mock response matching what the OTX API returns;
+the adapter's normaliser must produce valid ioc_network objects.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from threat_intel_mcp.adapters.otx import OTXAdapter, _normalize_indicator
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class FakeCredentials:
+    def get(self, adapter_name: str, key: str) -> str:
+        return "test-otx-api-key-do-not-use-in-prod"
+
+
+@pytest.fixture()
+def adapter():
+    return OTXAdapter(FakeCredentials())
+
+
+# Minimal pulse response used by most integration tests.
+_SINGLE_PAGE_RESPONSE = {
+    "results": [
+        {
+            "name": "Test Pulse",
+            "indicators": [
+                {"type": "IPv4", "indicator": "1.2.3.4", "description": "C2"},
+                {"type": "domain", "indicator": "evil.example.com", "description": ""},
+                {"type": "URL", "indicator": "https://evil.example.com/payload", "description": ""},
+                {"type": "FileHash-MD5", "indicator": "abc123", "description": ""},
+                {"type": "unknown_type", "indicator": "blah", "description": ""},
+            ],
+        }
+    ],
+    "next": None,
+}
+
+_OTX_BASE = "https://otx.alienvault.com/api/v1/pulses/subscribed"
+
+# Regex that matches the subscribed endpoint regardless of query params.
+# modified_since changes with wall-clock time so we match on URL prefix only.
+_OTX_SUBSCRIBED_RE = re.compile(
+    r"^https://otx\.alienvault\.com/api/v1/pulses/subscribed(\?.*)?$"
+)
+
+
+def _make_json_response(data: dict, status_code: int = 200) -> httpx.Response:
+    """Build an httpx.Response with JSON body (used in callbacks)."""
+    import json as _json
+
+    return httpx.Response(
+        status_code=status_code,
+        headers={"Content-Type": "application/json"},
+        content=_json.dumps(data).encode(),
+    )
+
+
+def _make_error_response(status_code: int) -> httpx.Response:
+    return httpx.Response(status_code=status_code)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _normalize_indicator
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeIndicator:
+    def test_normalize_ipv4(self):
+        ind = {"type": "IPv4", "indicator": "1.2.3.4", "description": "C2"}
+        result = _normalize_indicator(ind)
+        assert result is not None
+        assert result["type"] == "IPv4"
+        assert result["value"] == "1.2.3.4"
+        assert result["confidence"] == "High"
+        assert result["source"] == "AlienVault OTX"
+        assert result["action"] == "alert"
+        assert result["tlp"] == "WHITE"
+        assert "otx" in result["tags"]
+
+    def test_normalize_domain(self):
+        ind = {"type": "domain", "indicator": "evil.example.com", "description": ""}
+        result = _normalize_indicator(ind)
+        assert result is not None
+        assert result["type"] == "Domain"
+        assert result["value"] == "evil.example.com"
+        assert result["source"] == "AlienVault OTX"
+
+    def test_normalize_hostname_maps_to_domain(self):
+        ind = {"type": "hostname", "indicator": "host.evil.example.com", "description": ""}
+        result = _normalize_indicator(ind)
+        assert result is not None
+        assert result["type"] == "Domain"
+
+    def test_normalize_url(self):
+        ind = {"type": "URL", "indicator": "https://evil.example.com/payload", "description": ""}
+        result = _normalize_indicator(ind)
+        assert result is not None
+        assert result["type"] == "URL"
+        assert result["value"] == "https://evil.example.com/payload"
+
+    def test_normalize_filehash_skipped(self):
+        ind = {"type": "FileHash-MD5", "indicator": "abc123", "description": ""}
+        result = _normalize_indicator(ind)
+        assert result is None
+
+    def test_normalize_filehash_sha256_skipped(self):
+        ind = {"type": "FileHash-SHA256", "indicator": "deadbeef" * 8, "description": ""}
+        result = _normalize_indicator(ind)
+        assert result is None
+
+    def test_normalize_unknown_type_skipped(self):
+        ind = {"type": "unknown_type", "indicator": "blah", "description": ""}
+        result = _normalize_indicator(ind)
+        assert result is None
+
+    def test_pulse_name_slug_in_tags(self):
+        ind = {"type": "IPv4", "indicator": "5.5.5.5", "description": ""}
+        result = _normalize_indicator(ind, pulse_name="Evil Botnet Campaign")
+        assert result is not None
+        assert "otx" in result["tags"]
+        assert "evil-botnet-campaign" in result["tags"]
+
+    def test_empty_indicator_value_skipped(self):
+        ind = {"type": "IPv4", "indicator": "", "description": ""}
+        result = _normalize_indicator(ind)
+        assert result is None
+
+    def test_created_field_mapped_to_first_seen(self):
+        ind = {
+            "type": "IPv4",
+            "indicator": "9.9.9.9",
+            "description": "",
+            "created": "2026-01-01T00:00:00",
+        }
+        result = _normalize_indicator(ind)
+        assert result is not None
+        assert result["first_seen"] == "2026-01-01T00:00:00"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: adapter.fetch() with mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestOTXAdapterFetch:
+    @pytest.mark.asyncio
+    async def test_fetch_returns_fetch_result(self, adapter, httpx_mock: HTTPXMock):
+        httpx_mock.add_callback(
+            lambda req: _make_json_response(_SINGLE_PAGE_RESPONSE),
+            url=_OTX_SUBSCRIBED_RE,
+            match_headers={"X-OTX-API-KEY": "test-otx-api-key-do-not-use-in-prod"},
+        )
+        result = await adapter.fetch(time_range="7d")
+        assert result.source == "AlienVault OTX"
+        assert result.tier == 2
+        assert result.record_count > 0
+        assert "subscribed" in result.feed_types_fetched
+
+    @pytest.mark.asyncio
+    async def test_fetch_skips_unsupported_types(self, adapter, httpx_mock: HTTPXMock):
+        httpx_mock.add_callback(
+            lambda req: _make_json_response(_SINGLE_PAGE_RESPONSE),
+            url=_OTX_SUBSCRIBED_RE,
+        )
+        result = await adapter.fetch(time_range="7d")
+        types = {ioc["type"] for ioc in result.iocs}
+        # Must include supported types
+        assert "IPv4" in types
+        assert "Domain" in types
+        assert "URL" in types
+        # File hashes and unknown types must be excluded
+        values = {ioc["value"] for ioc in result.iocs}
+        assert "abc123" not in values
+        assert "blah" not in values
+
+    @pytest.mark.asyncio
+    async def test_fetch_ioc_count_matches_supported_indicators(self, adapter, httpx_mock: HTTPXMock):
+        httpx_mock.add_callback(
+            lambda req: _make_json_response(_SINGLE_PAGE_RESPONSE),
+            url=_OTX_SUBSCRIBED_RE,
+        )
+        result = await adapter.fetch(time_range="7d")
+        # 5 indicators, 3 supported (IPv4, domain, URL), 2 skipped (FileHash-MD5, unknown_type)
+        assert result.record_count == 3
+
+    @pytest.mark.asyncio
+    async def test_fetch_paginates(self, adapter, httpx_mock: HTTPXMock):
+        page1_response = {
+            "results": [
+                {
+                    "name": "Pulse Page 1",
+                    "indicators": [
+                        {"type": "IPv4", "indicator": "10.0.0.1", "description": ""},
+                        {"type": "IPv4", "indicator": "10.0.0.2", "description": ""},
+                    ],
+                }
+            ],
+            "next": f"{_OTX_BASE}?page=2",
+        }
+        page2_response = {
+            "results": [
+                {
+                    "name": "Pulse Page 2",
+                    "indicators": [
+                        {"type": "IPv4", "indicator": "10.0.0.3", "description": ""},
+                    ],
+                }
+            ],
+            "next": None,
+        }
+
+        # Serve page1 on first request, page2 on second (paginated via "next" URL).
+        responses = iter([page1_response, page2_response])
+
+        httpx_mock.add_callback(
+            lambda req: _make_json_response(next(responses)),
+            url=_OTX_SUBSCRIBED_RE,
+            is_reusable=True,
+        )
+
+        result = await adapter.fetch(time_range="7d")
+        assert result.record_count == 3
+        values = {ioc["value"] for ioc in result.iocs}
+        assert "10.0.0.1" in values
+        assert "10.0.0.2" in values
+        assert "10.0.0.3" in values
+
+    @pytest.mark.asyncio
+    async def test_cache_avoids_second_request(self, adapter, httpx_mock: HTTPXMock):
+        # Only one response registered; second call must be served from cache.
+        httpx_mock.add_callback(
+            lambda req: _make_json_response(_SINGLE_PAGE_RESPONSE),
+            url=_OTX_SUBSCRIBED_RE,
+        )
+        await adapter.fetch(time_range="7d")
+        # Second fetch must not make a new HTTP request (cache hit).
+        result = await adapter.fetch(time_range="7d")
+        assert result.record_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retrieved_at_is_iso8601(self, adapter, httpx_mock: HTTPXMock):
+        httpx_mock.add_callback(
+            lambda req: _make_json_response(_SINGLE_PAGE_RESPONSE),
+            url=_OTX_SUBSCRIBED_RE,
+        )
+        result = await adapter.fetch(time_range="7d")
+        # Must not raise; fromisoformat accepts "+00:00" suffix.
+        parsed = datetime.fromisoformat(result.retrieved_at)
+        assert parsed.tzinfo is not None
+
+    @pytest.mark.asyncio
+    async def test_all_iocs_have_required_fields(self, adapter, httpx_mock: HTTPXMock):
+        httpx_mock.add_callback(
+            lambda req: _make_json_response(_SINGLE_PAGE_RESPONSE),
+            url=_OTX_SUBSCRIBED_RE,
+        )
+        result = await adapter.fetch(time_range="7d")
+        for ioc in result.iocs:
+            assert "type" in ioc
+            assert "value" in ioc
+            assert "confidence" in ioc
+            assert "source" in ioc
+            assert ioc["source"] == "AlienVault OTX"
+            assert ioc["confidence"] == "High"
+            assert ioc["tlp"] == "WHITE"
+            assert ioc["action"] == "alert"
+
+    @pytest.mark.asyncio
+    async def test_empty_results_returns_zero_iocs(self, adapter, httpx_mock: HTTPXMock):
+        httpx_mock.add_callback(
+            lambda req: _make_json_response({"results": [], "next": None}),
+            url=_OTX_SUBSCRIBED_RE,
+        )
+        result = await adapter.fetch(time_range="7d")
+        assert result.record_count == 0
+        assert result.iocs == []
+        assert result.partial_failure == []
+
+    @pytest.mark.asyncio
+    async def test_http_error_recorded_as_partial_failure(self, adapter, httpx_mock: HTTPXMock):
+        httpx_mock.add_callback(
+            lambda req: _make_error_response(401),
+            url=_OTX_SUBSCRIBED_RE,
+        )
+        result = await adapter.fetch(time_range="7d")
+        assert "subscribed" in result.partial_failure
+        assert result.record_count == 0
+
+    @pytest.mark.asyncio
+    async def test_otx_tag_present_on_all_iocs(self, adapter, httpx_mock: HTTPXMock):
+        httpx_mock.add_callback(
+            lambda req: _make_json_response(_SINGLE_PAGE_RESPONSE),
+            url=_OTX_SUBSCRIBED_RE,
+        )
+        result = await adapter.fetch(time_range="7d")
+        for ioc in result.iocs:
+            assert "otx" in ioc["tags"]


### PR DESCRIPTION
## Summary

- Adds `mcp/src/threat_intel_mcp/adapters/otx.py`: `OTXAdapter` implementing the `SourceAdapter` protocol. Fetches subscribed OTX pulses via `X-OTX-API-KEY` header auth, with `modified_since` filtering, up to 10 pages of pagination, and a 60-minute in-process cache keyed by `"otx_subscribed"`. Top-level `_normalize_indicator` function maps OTX indicator types (IPv4, IPv6, domain, hostname, URL) to `ioc_network` schema; file hash types and unknowns are silently skipped.
- Adds `mcp/tests/test_otx.py`: 20 tests (10 unit for `_normalize_indicator`, 10 integration using `pytest-httpx` callbacks to handle the wall-clock-varying `modified_since` query param). Covers all 10 required test cases from the spec plus bonus edge cases.
- Updates `mcp/src/threat_intel_mcp/server.py`: adds `otx_fetch_iocs` MCP tool following the same pattern as `qfeeds_fetch_iocs`; handles `CredentialError` and `KeyError` gracefully. Updates `list_available_feeds` to include OTX. Updates docstring to mention `OTX_API_KEY`.
- Updates `docs/architecture.md`: promotes OTX from dashed/planned node to solid implemented node; adds `OTX_API_KEY` to credential path; adds solid arrows for OTX data flow; removes OTX from planned nodes.
- Bumps `mcp/pyproject.toml` version from `0.2.0` to `0.3.0`.

## Test plan

- [ ] `cd mcp && python -m pytest tests/ -v` — 60 tests pass (40 existing + 20 new)
- [ ] `ruff check src/ tests/` — clean
- [ ] Confirm `otx_fetch_iocs` tool appears in `list_available_feeds` output
- [ ] Confirm `OTX_API_KEY` env var is picked up via `EnvCredentialProvider` (env var name: `OTX_API_KEY` from `credentials.get("otx", "api_key")`)
- [ ] Confirm `CredentialError` when `OTX_API_KEY` is not set returns a graceful error dict (no server crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ)_