### PR TITLE
Update READMEs to reflect M3 Phase 3 live feed adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ threat-intel/
 |   +-- cyber-threat-intel-skill.md                 # self-contained Agent Skill
 +-- docs/
 |   +-- architecture.md                             # Mermaid data-flow diagram (intel feed operations)
-+-- mcp/                                             # threat-intel-mcp server (Phase 1)
++-- mcp/                                             # threat-intel-mcp server (v0.3.0)
     +-- pyproject.toml                               # package definition (threat-intel-mcp)
     +-- src/threat_intel_mcp/
     |   +-- server.py                                # FastMCP stdio server entry point
@@ -113,13 +113,22 @@ threat-intel/
     |   +-- audit.py                                 # structured audit logging + secret redaction
     |   +-- adapters/
     |   |   +-- base.py                              # FetchResult dataclass, SourceAdapter protocol
-    |   |   +-- qfeeds.py                            # Q-Feeds HTTP adapter (paginated, cached)
+    |   |   +-- qfeeds.py                            # Q-Feeds HTTP adapter (paginated, 20-min cache)
+    |   |   +-- abuseipdb.py                         # AbuseIPDB blacklist adapter (60-min cache)
+    |   |   +-- virustotal.py                        # VirusTotal Intelligence adapter (15-min cache)
+    |   |   +-- otx.py                               # AlienVault OTX pulses adapter (60-min cache)
     |   +-- vault/
     |       +-- base.py                              # CredentialProvider protocol
-    |       +-- env.py                               # EnvCredentialProvider (Phase 1: env vars)
+    |       +-- env.py                               # EnvCredentialProvider (env vars)
+    |       +-- hashicorp.py                         # VaultCredentialProvider (AppRole + KV v2)
+    |       +-- factory.py                           # credential_provider_from_env() selector
     +-- tests/
         +-- test_normalize.py                        # schema validation + dedup tests
         +-- test_qfeeds.py                           # Q-Feeds unit + httpx mock integration tests
+        +-- test_abuseipdb.py                        # AbuseIPDB unit + integration tests
+        +-- test_virustotal.py                       # VirusTotal unit + integration tests
+        +-- test_otx.py                              # OTX unit + integration tests
+        +-- test_vault.py                            # Vault provider + factory tests
 ```
 
 ---
@@ -178,12 +187,17 @@ Full breakdown: [skills/cyber-threat-intel/references/scoring.md](skills/cyber-t
 
 The `mcp/` directory contains `threat-intel-mcp`, an [MCP](https://modelcontextprotocol.io/) server that gives Claude Code live access to threat intelligence feeds. It is the runtime counterpart to the prompt skill — the skill structures the analysis; the MCP server fetches real indicators.
 
-**Phase 1 (current):** Q-Feeds adapter with env-var credentials.
+**Current (v0.3.0, Phase 3):** Q-Feeds, AbuseIPDB, VirusTotal Intelligence, and AlienVault OTX adapters with env-var or HashiCorp Vault credentials.
 
 ```bash
 cd mcp
 pip install -e .
-QFEEDS_API_KEY=your-key threat-intel-mcp   # stdio transport; wire up in .claude/mcp.json
+# Set whichever API keys you have:
+export QFEEDS_API_KEY=...
+export ABUSEIPDB_API_KEY=...
+export VT_API_KEY=...
+export OTX_API_KEY=...
+threat-intel-mcp   # stdio transport; wire into Claude Code via .claude/mcp.json
 ```
 
 Configure in Claude Code (`~/.claude/mcp.json` or project `.claude/mcp.json`):
@@ -193,15 +207,20 @@ Configure in Claude Code (`~/.claude/mcp.json` or project `.claude/mcp.json`):
   "mcpServers": {
     "threat-intel": {
       "command": "threat-intel-mcp",
-      "env": { "QFEEDS_API_KEY": "your-key-here" }
+      "env": {
+        "QFEEDS_API_KEY": "your-qfeeds-key",
+        "ABUSEIPDB_API_KEY": "your-abuseipdb-key",
+        "VT_API_KEY": "your-vt-key",
+        "OTX_API_KEY": "your-otx-key"
+      }
     }
   }
 }
 ```
 
-Tools exposed: `qfeeds_fetch_iocs`, `list_available_feeds`.
+Tools exposed: `qfeeds_fetch_iocs`, `abuseipdb_fetch_blocklist`, `virustotal_fetch_iocs`, `otx_fetch_iocs`, `list_available_feeds`.
 
-See `mcp/README.md` for full setup, feed types, and planned phases (Vault credentials, additional adapters).
+See [`mcp/README.md`](mcp/README.md) for full setup, Vault credentials, and feed-specific details.
 
 ---
 
@@ -218,7 +237,7 @@ CI runs the same validation plus version/persona/tier parity checks across `spec
 
 ## Architecture
 
-See [docs/architecture.md](docs/architecture.md) for a Mermaid flowchart showing the full data flow: User → Skill → MCP Server → CredentialProvider → QFeedsAdapter → Q-Feeds API → normalize.py → FetchResult → report output. Future adapters (AlienVault OTX, AbuseIPDB, VirusTotal) are shown as planned components.
+See [docs/architecture.md](docs/architecture.md) for a Mermaid flowchart showing the full data flow: User → Skill → MCP Server → CredentialProvider → Adapters (Q-Feeds, AbuseIPDB, VirusTotal, AlienVault OTX) → external feed APIs → normalize.py → FetchResult → report output.
 
 ---
 
@@ -235,9 +254,8 @@ The skill is built to be driven programmatically (Claude Code, an OpenAI-based p
 
 ## Limitations
 
-- **Knowledge cutoff.** Output reflects the model's training data. For breaking threats (last 24-48 hours), consult professional threat intelligence services -- this skill cannot surface intelligence newer than the model behind it.
-- **Illustrative IOCs.** Generated IOCs (IPs, hashes, domains) are examples drawn from known patterns in training data, not real-time indicators. Validate every IOC against trusted feeds before deploying to detection or blocking systems.
-- **No live feeds in the skill itself.** The prompt skill draws from training data, not real-time feeds. For live indicators, use the `mcp/` server with a valid Q-Feeds API key (or a future adapter). Sources listed in the Source Matrix are references, not active API integrations.
+- **Knowledge cutoff (without MCP).** Without the `threat-intel-mcp` server configured, output reflects the model's training data only. For breaking threats, configure live feed integration (see [MCP Server section](#mcp-server-mcp)) or consult professional threat intelligence services.
+- **Validate IOCs before deploying.** Whether IOCs come from training data or live feeds, validate them against additional trusted sources before deploying to detection or blocking systems. Live feed IOCs are current at retrieval time but may include false positives — treat them as indicators to investigate, not as confirmed-malicious block entries.
 - This skill structures AI output; it does not guarantee accuracy. Always verify critical findings.
 - Detection rules should be tested in a lab environment before production deployment.
 - This is not a replacement for professional threat intelligence services or incident response.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -9,17 +9,17 @@ Implements the architecture described in [threat-intel issue #1](https://github.
 ```
 Claude Code
   │  skill: threat-intel  (SKILL.md + output.schema.json)
-  │  skill_input.feed_integrations = [{"name": "Q-Feeds", "tier": 2}]
+  │  skill_input.feed_integrations = [{"name": "Q-Feeds", "tier": 2}, ...]
   │
-  │  MCP tool call: qfeeds_fetch_iocs(time_range="7d")
+  │  MCP tool calls: qfeeds_fetch_iocs / abuseipdb_fetch_blocklist /
+  │                  virustotal_fetch_iocs / otx_fetch_iocs
   ▼
-threat-intel-mcp  (this repo, stdio MCP server)
-  │  reads QFEEDS_API_KEY from CredentialProvider
-  │  calls https://api.qfeeds.com/api (malware_ip, malware_domains)
-  │  normalises → ioc_network[] per output.schema.json
+threat-intel-mcp  (this package, stdio MCP server)
+  │  reads API keys from CredentialProvider (env vars or HashiCorp Vault)
+  │  calls upstream feed APIs; normalises → ioc_network[] per output.schema.json
   │  schema-validates + deduplicates before returning
   ▼
-Claude receives ioc_network[], cites "Q-Feeds" in Coverage Ledger (R2/R5)
+Claude receives ioc_network[], cites sources in Coverage Ledger (R2/R5)
 ```
 
 ## Current state
@@ -34,8 +34,13 @@ Claude receives ioc_network[], cites "Q-Feeds" in Coverage Ledger (R2/R5)
 | MCP tool: `list_available_feeds` | ✅ Phase 1 |
 | pytest suite (no live calls) | ✅ Phase 1 |
 | HashiCorp Vault credential provider | ✅ Phase 2 |
-| VirusTotal / Shodan / Recorded Future adapters | Phase 3 |
-| gRPC / MQTT / WebSocket / GraphQL adapters | Phase 3 |
+| AbuseIPDB blacklist adapter | ✅ Phase 3 |
+| VirusTotal Intelligence adapter (malicious IPs + domains) | ✅ Phase 3 |
+| AlienVault OTX subscribed-pulses adapter | ✅ Phase 3 |
+| MCP tool: `abuseipdb_fetch_blocklist` | ✅ Phase 3 |
+| MCP tool: `virustotal_fetch_iocs` | ✅ Phase 3 |
+| MCP tool: `otx_fetch_iocs` | ✅ Phase 3 |
+| gRPC / MQTT / WebSocket / GraphQL adapters | Phase 4 |
 | Circuit breakers, async fan-out, egress allowlist | Phase 4 |
 
 ## Quick start
@@ -46,14 +51,19 @@ Claude receives ioc_network[], cites "Q-Feeds" in Coverage Ledger (R2/R5)
 pip install -e ".[dev]"
 ```
 
-### 2. Set your API key
+### 2. Set your API keys
 
 ```bash
 cp .env.example .env
-# Edit .env and set QFEEDS_API_KEY
-# Obtain your key at: https://tip.qfeeds.com (Manage API Keys → Create Free API Key)
+# Edit .env and set the keys you have:
+#   QFEEDS_API_KEY      — https://tip.qfeeds.com (Manage API Keys)
+#   ABUSEIPDB_API_KEY   — https://www.abuseipdb.com/account/api
+#   VT_API_KEY          — https://www.virustotal.com/gui/user/apikey
+#   OTX_API_KEY         — https://otx.alienvault.com/settings (API Integration)
 export $(grep -v '^#' .env | xargs)
 ```
+
+Keys are optional individually — the server starts with whatever keys are configured and marks unconfigured feeds as `unverified` in the Coverage Ledger.
 
 ### 3. Run the tests
 
@@ -71,12 +81,17 @@ Add to your Claude Code MCP config (`~/.claude/mcp_servers.json` or `.claude/mcp
     "threat-intel-mcp": {
       "command": "threat-intel-mcp",
       "env": {
-        "QFEEDS_API_KEY": "your-api-key-here"
+        "QFEEDS_API_KEY": "your-qfeeds-key",
+        "ABUSEIPDB_API_KEY": "your-abuseipdb-key",
+        "VT_API_KEY": "your-virustotal-key",
+        "OTX_API_KEY": "your-otx-key"
       }
     }
   }
 }
 ```
+
+Omit keys you don't have — the server runs with however many feeds are configured.
 
 ## Vault Credentials (Phase 2)
 
@@ -102,16 +117,13 @@ Secrets must be stored in KV v2 under:
 {mount_point}/data/{adapter_name}/{key}
 ```
 
-The default mount point is `secret`. Example for the Q-Feeds API key:
-
-```
-secret/data/qfeeds/api_key
-```
-
-Create it with:
+The default mount point is `secret`. Examples:
 
 ```bash
-vault kv put secret/qfeeds api_key=<your-qfeeds-key>
+vault kv put secret/qfeeds    api_key=<your-qfeeds-key>
+vault kv put secret/abuseipdb api_key=<your-abuseipdb-key>
+vault kv put secret/virustotal api_key=<your-vt-key>
+vault kv put secret/otx       api_key=<your-otx-key>
 ```
 
 ### Claude Code MCP config (Vault mode)
@@ -136,41 +148,52 @@ vault kv put secret/qfeeds api_key=<your-qfeeds-key>
 In Claude Code, after the MCP server is connected:
 
 ```
-/threat-intel
-feed_integrations: [{"name": "Q-Feeds", "tier": 2, "access_level": "premium"}]
+/cyber-threat-intel
+feed_integrations: [
+  {"name": "Q-Feeds",       "tier": 2, "access_level": "premium"},
+  {"name": "AbuseIPDB",     "tier": 3, "access_level": "free"},
+  {"name": "VirusTotal",    "tier": 2, "access_level": "intelligence"},
+  {"name": "AlienVault OTX","tier": 2, "access_level": "community"}
+]
 ```
 
-Claude will call `qfeeds_fetch_iocs`, blend live Q-Feeds IOCs with its training-data knowledge, and cite Q-Feeds in the Coverage Ledger (Appendix A) without marking findings as `unverified`.
+Claude will call the relevant `*_fetch_iocs` tools, blend live IOCs with its training-data knowledge, and cite each source in the Coverage Ledger (Appendix A) without marking findings as `unverified`.
 
 ## Security notes
 
-- `EnvCredentialProvider` reads `QFEEDS_API_KEY` from the environment. Suitable for local development only — env vars are visible in process listings and container inspection. Use `VaultCredentialProvider` for any non-local deployment (see [Vault Credentials](#vault-credentials-phase-2) above).
-- The API key is used for HTTP Basic auth. It never appears in logs — `audit.py` redacts auth headers and credential-bearing query strings.
-- Upstream responses are schema-validated before being returned to Claude. Malformed IOCs (including any prompt-injection attempt embedded in feed data) are dropped.
+- `EnvCredentialProvider` reads API keys from the environment. Suitable for local development only — env vars are visible in process listings and container inspection. Use `VaultCredentialProvider` for any non-local deployment.
+- API keys are passed as HTTP headers (or Basic auth for Q-Feeds). They never appear in logs — `audit.py` redacts auth headers and credential-bearing query strings.
+- Upstream responses are schema-validated before being returned to Claude. Malformed IOCs (including any prompt-injection attempt embedded in feed data) are dropped at the normalisation layer.
 
 ## Project structure
 
 ```
 src/threat_intel_mcp/
-├── server.py          MCP entrypoint; tool registration
+├── server.py              MCP entrypoint; tool registration
 ├── vault/
-│   ├── base.py        CredentialProvider Protocol + CredentialError
-│   ├── env.py         EnvCredentialProvider (dev only)
-│   ├── hashicorp.py   VaultCredentialProvider (AppRole + KV v2)
-│   └── factory.py     credential_provider_from_env() selector
+│   ├── base.py            CredentialProvider Protocol + CredentialError
+│   ├── env.py             EnvCredentialProvider (dev only)
+│   ├── hashicorp.py       VaultCredentialProvider (AppRole + KV v2)
+│   └── factory.py         credential_provider_from_env() selector
 ├── adapters/
-│   ├── base.py        SourceAdapter Protocol + FetchResult dataclass
-│   └── qfeeds.py      Q-Feeds REST adapter
-├── normalize.py       Schema validation + deduplication
-└── audit.py           Structured logging with secret redaction
+│   ├── base.py            SourceAdapter Protocol + FetchResult dataclass
+│   ├── qfeeds.py          Q-Feeds REST adapter (20-min cache)
+│   ├── abuseipdb.py       AbuseIPDB blacklist adapter (60-min cache)
+│   ├── virustotal.py      VirusTotal Intelligence adapter (15-min cache, 15s rate limit)
+│   └── otx.py             AlienVault OTX subscribed-pulses adapter (60-min cache)
+├── normalize.py           Schema validation + deduplication
+└── audit.py               Structured logging with secret redaction
 tests/
-├── test_qfeeds.py     Adapter tests (pytest-httpx, no live calls)
-├── test_normalize.py  Normaliser / validator tests
-└── test_vault.py      Vault provider + factory tests (hvac mocked)
+├── test_qfeeds.py         Q-Feeds adapter tests (pytest-httpx, no live calls)
+├── test_abuseipdb.py      AbuseIPDB adapter tests
+├── test_virustotal.py     VirusTotal adapter tests
+├── test_otx.py            OTX adapter tests
+├── test_normalize.py      Normaliser / validator tests
+└── test_vault.py          Vault provider + factory tests (hvac mocked)
 ```
 
 ## Relationship to threat-intel
 
-This repo provides the **runtime and live data**. [`kj299/threat-intel`](https://github.com/kj299/threat-intel) provides the **prompt and schema**. The AI assistant uses both together: the skill structures the report; this server supplies current IOCs from subscribed feeds.
+This package provides the **runtime and live data**. [`kj299/threat-intel`](https://github.com/kj299/threat-intel) provides the **prompt and schema**. The AI assistant uses both together: the skill structures the report; this server supplies current IOCs from subscribed feeds.
 
 Schema contract: `ioc_network` objects from this server match the definition in [`skills/cyber-threat-intel/schemas/output.schema.json`](https://github.com/kj299/threat-intel/blob/main/skills/cyber-threat-intel/schemas/output.schema.json) exactly.


### PR DESCRIPTION
## Summary

- **`README.md`**: Update repo layout to list all 4 adapters and 6 test files; update MCP Server section from "Phase 1" to v0.3.0/Phase 3 with all 4 API keys and tools; fix Architecture description (no longer mentions planned adapters — all 4 are implemented); replace stale "No live feeds / Illustrative IOCs" limitations with accurate guidance that live feed integration is optional via the MCP server.
- **`mcp/README.md`**: Update status table (AbuseIPDB, VirusTotal, OTX marked Phase 3 complete); update Quick Start to list all 4 API keys with source URLs; expand Vault section with `kv put` examples for all 4 adapters; update skill usage example with all 4 `feed_integrations` entries; update project structure to show all 4 adapters and all 6 test files.

## Test plan

- [ ] Verify no broken links in README.md (architecture.md, mcp/README.md references)
- [ ] Confirm status table in mcp/README.md matches actual implemented adapters
- [ ] Confirm Limitations section accurately describes MCP-optional live feed behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ)_