### PR TITLE
Add concurrent feed fan-out with per-source circuit breakers (v0.4.0)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,10 @@ flowchart TD
     end
 
     subgraph MCP["threat-intel-mcp (stdio transport)"]
-        Server["MCP Server\nserver.py\ntools: qfeeds_fetch_iocs\n       abuseipdb_fetch_blocklist\n       virustotal_fetch_iocs\n       otx_fetch_iocs"]
+        Server["MCP Server\nserver.py\ntools: qfeeds_fetch_iocs\n       abuseipdb_fetch_blocklist\n       virustotal_fetch_iocs\n       otx_fetch_iocs\n       fetch_all_iocs\n       list_available_feeds"]
+
+        FanOut["fetch_all_iocs fan-out\nfanout.py\nasyncio.gather over all sources\nmerge + cross-source dedup"]
+        Resilience["resilience.py\nguarded_fetch per source\nCircuitBreaker + backoff retry"]
 
         subgraph Cred["CredentialProvider"]
             EnvCred["Phase 1: EnvCredentialProvider\nreads QFEEDS_API_KEY\nreads ABUSEIPDB_API_KEY\nreads VT_API_KEY\nreads OTX_API_KEY"]
@@ -39,6 +42,13 @@ flowchart TD
 
     User -->|"invokes skill"| Skill
     Skill -->|"calls MCP tool"| Server
+    Server -->|"fetch_all_iocs"| FanOut
+    FanOut -->|"concurrent per-source call"| Resilience
+    Resilience -->|"guarded_fetch"| QFeeds
+    Resilience -->|"guarded_fetch"| AbuseIPDB
+    Resilience -->|"guarded_fetch"| VT
+    Resilience -->|"guarded_fetch"| OTX
+    FanOut -->|"merged + deduped IOCs\npartial/open-circuit -> coverage_ledger"| Server
     Server --> EnvCred
     Server -.->|"Phase 2"| VaultCred
     EnvCred -->|"api_key"| QFeeds
@@ -73,7 +83,9 @@ flowchart TD
 | Component | File | Role |
 |-----------|------|------|
 | Skill | `skills/cyber-threat-intel/SKILL.md` | Entrypoint; guides analysis workflow and report structure |
-| MCP Server | `mcp/src/threat_intel_mcp/server.py` | FastMCP stdio server; exposes `qfeeds_fetch_iocs`, `abuseipdb_fetch_blocklist`, `virustotal_fetch_iocs`, `otx_fetch_iocs`, and `list_available_feeds` |
+| MCP Server | `mcp/src/threat_intel_mcp/server.py` | FastMCP stdio server; exposes `qfeeds_fetch_iocs`, `abuseipdb_fetch_blocklist`, `virustotal_fetch_iocs`, `otx_fetch_iocs`, `fetch_all_iocs`, and `list_available_feeds` |
+| Fan-out | `mcp/src/threat_intel_mcp/fanout.py` | `fetch_all_iocs` backend: runs every configured adapter concurrently via `asyncio.gather`, validates + dedupes per source, merges into one deduplicated set, surfaces degraded sources to the Coverage Ledger |
+| Resilience | `mcp/src/threat_intel_mcp/resilience.py` | `CircuitBreaker` (closed/open/half-open) + `retry_with_backoff` (exponential backoff + jitter) wrapped by `guarded_fetch`; isolates one flaky feed from the rest |
 | EnvCredentialProvider | `mcp/src/threat_intel_mcp/vault/env.py` | Phase 1: reads `QFEEDS_API_KEY`, `ABUSEIPDB_API_KEY`, `VT_API_KEY`, and `OTX_API_KEY` from environment |
 | VaultCredentialProvider | `mcp/src/threat_intel_mcp/vault/` | Phase 2: reads credentials from HashiCorp Vault |
 | QFeedsAdapter | `mcp/src/threat_intel_mcp/adapters/qfeeds.py` | Fetches paginated malware IP and domain feeds; 20-min in-process cache |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -11,15 +11,18 @@ Claude Code
   │  skill: threat-intel  (SKILL.md + output.schema.json)
   │  skill_input.feed_integrations = [{"name": "Q-Feeds", "tier": 2}, ...]
   │
-  │  MCP tool calls: qfeeds_fetch_iocs / abuseipdb_fetch_blocklist /
-  │                  virustotal_fetch_iocs / otx_fetch_iocs
+  │  MCP tool calls: fetch_all_iocs            (all feeds at once)
+  │                  qfeeds_fetch_iocs         (single feed)
+  │                  abuseipdb_fetch_blocklist / virustotal_fetch_iocs / otx_fetch_iocs
   ▼
 threat-intel-mcp  (this package, stdio MCP server)
   │  reads API keys from CredentialProvider (env vars or HashiCorp Vault)
+  │  fetch_all_iocs fans out concurrently, each source behind a circuit breaker
   │  calls upstream feed APIs; normalises → ioc_network[] per output.schema.json
-  │  schema-validates + deduplicates before returning
+  │  schema-validates + deduplicates (per-source and across sources) before returning
+  │  a failing/unconfigured/open-circuit feed degrades to "unverified", never crashes
   ▼
-Claude receives ioc_network[], cites sources in Coverage Ledger (R2/R5)
+Claude receives ioc_network[] + coverage_ledger, cites sources (R2/R5)
 ```
 
 ## Current state
@@ -40,8 +43,11 @@ Claude receives ioc_network[], cites sources in Coverage Ledger (R2/R5)
 | MCP tool: `abuseipdb_fetch_blocklist` | ✅ Phase 3 |
 | MCP tool: `virustotal_fetch_iocs` | ✅ Phase 3 |
 | MCP tool: `otx_fetch_iocs` | ✅ Phase 3 |
-| gRPC / MQTT / WebSocket / GraphQL adapters | Phase 4 |
-| Circuit breakers, async fan-out, egress allowlist | Phase 4 |
+| Concurrent fan-out (`fetch_all_iocs`) | ✅ Phase 4 |
+| Circuit breakers + backoff retry per source | ✅ Phase 4 |
+| Partial-failure surfacing → Coverage Ledger | ✅ Phase 4 |
+| Egress allowlist, response sanitization, rotation playbook | Phase 4 (pending) |
+| gRPC / MQTT / WebSocket / GraphQL adapters | Phase 3+ (needs named feeds) |
 
 ## Quick start
 
@@ -181,6 +187,8 @@ src/threat_intel_mcp/
 │   ├── abuseipdb.py       AbuseIPDB blacklist adapter (60-min cache)
 │   ├── virustotal.py      VirusTotal Intelligence adapter (15-min cache, 15s rate limit)
 │   └── otx.py             AlienVault OTX subscribed-pulses adapter (60-min cache)
+├── fanout.py              fetch_all_iocs: concurrent multi-source merge + dedup
+├── resilience.py          CircuitBreaker + retry_with_backoff + guarded_fetch
 ├── normalize.py           Schema validation + deduplication
 └── audit.py               Structured logging with secret redaction
 tests/
@@ -188,6 +196,8 @@ tests/
 ├── test_abuseipdb.py      AbuseIPDB adapter tests
 ├── test_virustotal.py     VirusTotal adapter tests
 ├── test_otx.py            OTX adapter tests
+├── test_fanout.py         Fan-out merge / dedup / degrade tests (fake adapters)
+├── test_resilience.py     Circuit breaker + backoff retry tests
 ├── test_normalize.py      Normaliser / validator tests
 └── test_vault.py          Vault provider + factory tests (hvac mocked)
 ```

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "threat-intel-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server that delivers live threat intelligence feeds to Claude, normalised to the threat-intel skill schema"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/mcp/src/threat_intel_mcp/fanout.py
+++ b/mcp/src/threat_intel_mcp/fanout.py
@@ -1,0 +1,157 @@
+"""Concurrent multi-source IOC fan-out with per-source resilience.
+
+Runs every configured adapter's ``.fetch()`` concurrently, each wrapped in a
+circuit breaker + bounded backoff retry. Per-source output is schema-validated
+and deduplicated, then merged into a single deduplicated IOC set. A failing,
+credential-less, or open-circuit source is surfaced as a degraded
+Coverage-Ledger entry instead of failing the whole fan-out — this is the runtime
+analogue of the threat-intel skill's R5 "surface partial coverage honestly" rule.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from .adapters.base import FetchResult, SourceAdapter
+from .normalize import deduplicate_iocs, validate_iocs
+from .resilience import CircuitBreaker, CircuitOpenError, guarded_fetch
+
+logger = logging.getLogger(__name__)
+
+# Keys copied from each per-source result into the compact ``per_source`` summary
+# (the full IOC lists live only in the merged ``iocs`` array, not duplicated here).
+_SUMMARY_KEYS = (
+    "source",
+    "tier",
+    "status",
+    "record_count",
+    "latency_ms",
+    "partial_failure",
+    "error",
+)
+
+
+@dataclass
+class FeedSource:
+    """A single adapter plus the resilience state that guards it."""
+
+    adapter: SourceAdapter
+    tier: int
+    name: str
+    breaker: CircuitBreaker
+    # Exceptions treated as configuration errors: not retried, do not trip the
+    # breaker, and surface as an "unverified" Coverage-Ledger status.
+    no_retry_on: tuple[type[BaseException], ...] = field(default_factory=tuple)
+
+
+def _degraded(name: str, tier: int, reason: str, t0: float) -> dict[str, Any]:
+    return {
+        "source": name,
+        "tier": tier,
+        "status": "unverified",
+        "iocs": [],
+        "record_count": 0,
+        "latency_ms": round((time.monotonic() - t0) * 1000, 1),
+        "retrieved_at": "",
+        "feed_types_fetched": [],
+        "partial_failure": ["*"],
+        "error": reason,
+    }
+
+
+async def _run_source(
+    source: FeedSource, *, time_range: str, retry_kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    """Fetch one source; never raises — failures become degraded result dicts."""
+    name, tier = source.name, source.tier
+    t0 = time.monotonic()
+    try:
+        result = await guarded_fetch(
+            source.adapter,
+            source.breaker,
+            time_range=time_range,
+            feed_types=None,
+            no_retry_on=source.no_retry_on,
+            **retry_kwargs,
+        )
+    except source.no_retry_on as exc:  # credential / config error
+        logger.warning("fan-out source %s unconfigured: %s", name, type(exc).__name__)
+        return _degraded(name, tier, type(exc).__name__, t0)
+    except CircuitOpenError:
+        return _degraded(name, tier, "circuit_open", t0)
+    except Exception as exc:
+        logger.warning("fan-out source %s failed: %s", name, type(exc).__name__)
+        return _degraded(name, tier, type(exc).__name__, t0)
+
+    assert isinstance(result, FetchResult)
+    deduped = deduplicate_iocs(validate_iocs(result.iocs))
+    status = "consulted"
+    if result.partial_failure:
+        status = "partial" if deduped else "unverified"
+
+    return {
+        "source": name,
+        "tier": tier,
+        "status": status,
+        "iocs": deduped,
+        "record_count": len(deduped),
+        "latency_ms": result.latency_ms,
+        "retrieved_at": result.retrieved_at,
+        "feed_types_fetched": result.feed_types_fetched,
+        "partial_failure": result.partial_failure,
+        "error": None,
+    }
+
+
+async def fan_out(
+    sources: list[FeedSource],
+    *,
+    time_range: str = "7d",
+    retry_kwargs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Fetch every source concurrently and merge into one deduplicated IOC set.
+
+    Returns a dict with the merged ``iocs``, a per-source breakdown, the lists of
+    consulted vs. degraded sources, and a ``coverage_ledger`` ready to fold into
+    the skill's Appendix A. Cross-source duplicates are collapsed keeping the
+    highest-confidence copy, so ``record_count`` (the union) is typically smaller
+    than the sum of per-source counts.
+    """
+    retry_kwargs = retry_kwargs or {}
+    t0 = time.monotonic()
+
+    per_source = await asyncio.gather(
+        *(
+            _run_source(s, time_range=time_range, retry_kwargs=retry_kwargs)
+            for s in sources
+        )
+    )
+
+    merged = deduplicate_iocs([ioc for r in per_source for ioc in r["iocs"]])
+    latency_ms = round((time.monotonic() - t0) * 1000, 1)
+
+    consulted = [r["source"] for r in per_source if r["status"] == "consulted"]
+    degraded = [
+        {"source": r["source"], "status": r["status"], "error": r["error"]}
+        for r in per_source
+        if r["status"] != "consulted"
+    ]
+
+    return {
+        "iocs": merged,
+        "record_count": len(merged),
+        "retrieved_at": datetime.now(timezone.utc).isoformat(),
+        "latency_ms": latency_ms,
+        "sources_consulted": consulted,
+        "sources_degraded": degraded,
+        "per_source": [{k: r[k] for k in _SUMMARY_KEYS} for r in per_source],
+        "coverage_ledger": [
+            {"tier": r["tier"], "source": r["source"], "status": r["status"]}
+            for r in per_source
+        ],
+    }

--- a/mcp/src/threat_intel_mcp/resilience.py
+++ b/mcp/src/threat_intel_mcp/resilience.py
@@ -1,0 +1,187 @@
+"""Resilience primitives for adapter fan-out: circuit breaker + backoff retry.
+
+These wrap an individual adapter's ``.fetch()`` so a single slow or failing
+upstream feed degrades gracefully instead of failing a whole multi-source fetch.
+They map directly onto the threat-intel skill's R5 Coverage Ledger: a source
+whose circuit is open or whose retries are exhausted is surfaced as a partial /
+unverified entry rather than crashing the tool call.
+
+Clock, sleep, and RNG are injectable so the state machine and the backoff
+schedule are deterministically testable without real wall-clock waits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class CircuitOpenError(RuntimeError):
+    """Raised when a call is attempted while the circuit breaker is open."""
+
+
+@dataclass
+class CircuitBreaker:
+    """Per-source circuit breaker.
+
+    State transitions::
+
+        closed  --(failure_threshold consecutive failures)-->  open
+        open    --(reset_timeout elapsed)-->                    half_open
+        half_open --(trial succeeds)-->                         closed
+        half_open --(trial fails)-->                            open
+
+    The breaker does not itself perform calls; callers consult :meth:`allow`
+    before issuing one and report the outcome via :meth:`record_success` /
+    :meth:`record_failure`. ``clock`` defaults to ``time.monotonic`` and is
+    injectable for testing.
+    """
+
+    name: str
+    failure_threshold: int = 5
+    reset_timeout: float = 30.0
+    clock: Callable[[], float] = time.monotonic
+
+    _consecutive_failures: int = field(default=0, init=False)
+    _opened_at: float | None = field(default=None, init=False)
+    _half_open: bool = field(default=False, init=False)
+
+    @property
+    def state(self) -> str:
+        self._maybe_half_open()
+        if self._opened_at is None:
+            return "closed"
+        return "half_open" if self._half_open else "open"
+
+    def _maybe_half_open(self) -> None:
+        if (
+            self._opened_at is not None
+            and not self._half_open
+            and self.clock() - self._opened_at >= self.reset_timeout
+        ):
+            self._half_open = True
+            logger.info("circuit %s -> half_open", self.name)
+
+    def allow(self) -> bool:
+        """Return True if a call may proceed right now."""
+        self._maybe_half_open()
+        if self._opened_at is None:
+            return True
+        # Open: only the single half-open trial call is allowed through.
+        return self._half_open
+
+    def record_success(self) -> None:
+        if self._opened_at is not None or self._consecutive_failures:
+            logger.info("circuit %s -> closed (success)", self.name)
+        self._consecutive_failures = 0
+        self._opened_at = None
+        self._half_open = False
+
+    def record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._half_open:
+            # The half-open trial failed: re-open and restart the cooldown.
+            self._opened_at = self.clock()
+            self._half_open = False
+            logger.warning("circuit %s -> open (half-open trial failed)", self.name)
+        elif (
+            self._opened_at is None
+            and self._consecutive_failures >= self.failure_threshold
+        ):
+            self._opened_at = self.clock()
+            logger.warning(
+                "circuit %s -> open (%d consecutive failures)",
+                self.name,
+                self._consecutive_failures,
+            )
+
+
+async def retry_with_backoff(
+    factory: Callable[[], Awaitable[T]],
+    *,
+    retries: int = 2,
+    base_delay: float = 0.5,
+    max_delay: float = 4.0,
+    jitter: bool = True,
+    retry_on: tuple[type[BaseException], ...] = (Exception,),
+    no_retry_on: tuple[type[BaseException], ...] = (),
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    rng: Callable[[], float] = random.random,
+) -> T:
+    """Call ``factory()`` with exponential backoff + jitter on failure.
+
+    Makes up to ``retries + 1`` attempts. ``no_retry_on`` exceptions are raised
+    immediately without retrying — retrying a missing API key just wastes time.
+    The last exception is re-raised once attempts are exhausted.
+
+    Backoff delay for attempt ``n`` (0-indexed) is
+    ``min(max_delay, base_delay * 2**n)``, scaled into ``[0.5x, 1.0x]`` when
+    ``jitter`` is on to avoid thundering-herd retries across sources.
+    """
+    attempt = 0
+    while True:
+        try:
+            return await factory()
+        except no_retry_on:
+            raise
+        except retry_on as exc:
+            if attempt >= retries:
+                raise
+            delay = min(max_delay, base_delay * (2**attempt))
+            if jitter:
+                delay = delay * (0.5 + 0.5 * rng())
+            logger.warning(
+                "retry %d/%d after %s (sleeping %.2fs)",
+                attempt + 1,
+                retries,
+                type(exc).__name__,
+                delay,
+            )
+            await sleep(delay)
+            attempt += 1
+
+
+async def guarded_fetch(
+    adapter: object,
+    breaker: CircuitBreaker,
+    *,
+    time_range: str,
+    feed_types: list[str] | None = None,
+    no_retry_on: tuple[type[BaseException], ...] = (),
+    **retry_kwargs: object,
+) -> object:
+    """Run ``adapter.fetch`` behind ``breaker`` with backoff retry.
+
+    Raises :class:`CircuitOpenError` without calling the adapter when the circuit
+    is open. ``no_retry_on`` exceptions (e.g. credential errors) propagate
+    immediately and do **not** trip the breaker — a configuration error is not an
+    upstream-health signal. Any other exhausted-retry exception trips the breaker
+    and propagates.
+    """
+    if not breaker.allow():
+        raise CircuitOpenError(f"{breaker.name} circuit is open")
+
+    async def _call() -> object:
+        return await adapter.fetch(time_range=time_range, feed_types=feed_types)  # type: ignore[attr-defined]
+
+    try:
+        result = await retry_with_backoff(
+            _call, no_retry_on=no_retry_on, **retry_kwargs  # type: ignore[arg-type]
+        )
+    except no_retry_on:
+        raise  # config error: leave breaker state untouched
+    except Exception:
+        breaker.record_failure()
+        raise
+
+    breaker.record_success()
+    return result

--- a/mcp/src/threat_intel_mcp/server.py
+++ b/mcp/src/threat_intel_mcp/server.py
@@ -23,7 +23,10 @@ from .adapters.abuseipdb import AbuseIPDBAdapter
 from .adapters.otx import OTXAdapter
 from .adapters.qfeeds import QFeedsAdapter, FEED_TYPES as QFEEDS_FEED_TYPES
 from .adapters.virustotal import VirusTotalAdapter, FEED_TYPES as VT_FEED_TYPES
+from .audit import log_tool_call
+from .fanout import FeedSource, fan_out
 from .normalize import deduplicate_iocs, validate_iocs
+from .resilience import CircuitBreaker
 from .vault.base import CredentialError
 from .vault.factory import credential_provider_from_env
 
@@ -40,6 +43,9 @@ mcp = FastMCP(
         "Live threat intelligence feed tools. Call these to retrieve current IOCs "
         "from subscribed commercial feeds (Q-Feeds Tier 2, AbuseIPDB Tier 3, "
         "VirusTotal Tier 2, AlienVault OTX Tier 2). "
+        "Use fetch_all_iocs to query every configured feed at once (concurrent, "
+        "with per-source circuit breakers and merged deduplication), or call an "
+        "individual feed tool for a single source. "
         "After calling a feed tool, pass the returned iocs array as context and set "
         "skill_input.feed_integrations in the threat-intel skill output so the "
         "Coverage Ledger (Appendix A) correctly marks the source as consulted."
@@ -53,6 +59,17 @@ _qfeeds = QFeedsAdapter(_credentials)
 _abuseipdb = AbuseIPDBAdapter(_credentials)
 _virustotal = VirusTotalAdapter(_credentials)
 _otx = OTXAdapter(_credentials)
+
+# Fan-out registry: each source carries its own circuit breaker so one flaky
+# feed cannot take down a fetch_all_iocs call. Credential/config errors are
+# treated as non-retryable and surface as "unverified" in the Coverage Ledger.
+_CONFIG_ERRORS: tuple[type[BaseException], ...] = (CredentialError, KeyError)
+_FEED_SOURCES = [
+    FeedSource(_qfeeds, 2, "Q-Feeds", CircuitBreaker("Q-Feeds"), _CONFIG_ERRORS),
+    FeedSource(_abuseipdb, 3, "AbuseIPDB", CircuitBreaker("AbuseIPDB"), _CONFIG_ERRORS),
+    FeedSource(_virustotal, 2, "VirusTotal", CircuitBreaker("VirusTotal"), _CONFIG_ERRORS),
+    FeedSource(_otx, 2, "AlienVault OTX", CircuitBreaker("AlienVault OTX"), _CONFIG_ERRORS),
+]
 
 
 @mcp.tool()
@@ -327,6 +344,54 @@ async def otx_fetch_iocs(
 
 
 @mcp.tool()
+async def fetch_all_iocs(time_range: str = "7d") -> dict[str, Any]:
+    """Fetch and merge IOCs from ALL configured feeds concurrently (Tier 2-3 CTI).
+
+    Queries Q-Feeds, AbuseIPDB, VirusTotal, and AlienVault OTX at the same time,
+    schema-validates and deduplicates each source, then merges everything into a
+    single deduplicated ioc_network array (cross-source duplicates collapse to the
+    highest-confidence copy). Each source is guarded by its own circuit breaker and
+    bounded backoff retry, so one slow or failing feed degrades to an "unverified"
+    Coverage-Ledger entry instead of failing the whole call.
+
+    Prefer this over calling each feed tool serially: a typical report touches all
+    four feeds, and concurrent fan-out keeps total latency near the slowest single
+    feed rather than the sum.
+
+    Args:
+        time_range: Lookback window from the calling threat-intel skill (e.g. "7d").
+            Forwarded to each adapter; feeds that only expose a current blocklist
+            record it for the Coverage Ledger but return their live set.
+
+    Returns:
+        dict with keys: iocs (merged + deduplicated), record_count, retrieved_at,
+        latency_ms, sources_consulted, sources_degraded, per_source (compact
+        per-feed breakdown), and coverage_ledger (ready for Appendix A).
+
+    Usage with the threat-intel skill:
+        1. Call this tool once; receive the merged iocs and coverage_ledger.
+        2. Pass iocs as context to the skill invocation.
+        3. Set skill_input.feed_integrations from sources_consulted so the
+           Coverage Ledger marks each consulted source correctly; degraded
+           sources map to "unverified".
+    """
+    result = await fan_out(_FEED_SOURCES, time_range=time_range)
+
+    degraded = result["sources_degraded"]
+    log_tool_call(
+        "fetch_all_iocs",
+        {"time_range": time_range},
+        record_count=result["record_count"],
+        latency_ms=result["latency_ms"],
+        status="partial" if degraded else "ok",
+        error=(
+            f"degraded sources: {[d['source'] for d in degraded]}" if degraded else None
+        ),
+    )
+    return result
+
+
+@mcp.tool()
 async def list_available_feeds() -> dict[str, Any]:
     """List the threat intelligence feeds available in this MCP server instance.
 
@@ -396,7 +461,13 @@ async def list_available_feeds() -> dict[str, Any]:
                 "tool": "otx_fetch_iocs",
             },
         ],
-        "phase": "3 (Q-Feeds + AbuseIPDB + VirusTotal + AlienVault OTX + HashiCorp Vault or env-var credentials)",
+        "aggregate_tool": "fetch_all_iocs",
+        "aggregate_description": (
+            "Queries all credential-configured feeds concurrently, with per-source "
+            "circuit breakers and merged deduplication; degraded feeds surface as "
+            "'unverified' in the returned coverage_ledger."
+        ),
+        "phase": "3 (Q-Feeds + AbuseIPDB + VirusTotal + AlienVault OTX + concurrent fan-out + HashiCorp Vault or env-var credentials)",
         "planned": ["Shodan", "Recorded Future"],
     }
 

--- a/mcp/tests/test_fanout.py
+++ b/mcp/tests/test_fanout.py
@@ -1,0 +1,170 @@
+"""Tests for the concurrent multi-source fan-out.
+
+Uses in-memory fake adapters (no HTTP) so the merge/dedupe/degrade logic is
+exercised without network mocking or the module-level server singletons.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from threat_intel_mcp.adapters.base import FetchResult
+from threat_intel_mcp.fanout import FeedSource, fan_out
+from threat_intel_mcp.resilience import CircuitBreaker
+from threat_intel_mcp.vault.base import CredentialError
+
+
+def _ioc(value: str, *, type_: str = "IPv4", confidence: str = "High", source: str = "Fake"):
+    return {"type": type_, "value": value, "confidence": confidence, "source": source}
+
+
+class StubAdapter:
+    """Adapter returning a fixed FetchResult, or raising a fixed exception."""
+
+    def __init__(self, name, tier, *, iocs=None, partial=None, raises=None):
+        self.name = name
+        self.tier = tier
+        self._iocs = iocs or []
+        self._partial = partial or []
+        self._raises = raises
+        self.calls = 0
+
+    async def fetch(self, *, time_range: str, feed_types=None):
+        self.calls += 1
+        if self._raises is not None:
+            raise self._raises
+        return FetchResult(
+            iocs=self._iocs,
+            source=self.name,
+            tier=self.tier,
+            retrieved_at="2026-06-29T00:00:00+00:00",
+            record_count=len(self._iocs),
+            latency_ms=1.0,
+            feed_types_fetched=["default"],
+            partial_failure=self._partial,
+        )
+
+
+def _source(adapter, *, no_retry_on=(CredentialError, KeyError)):
+    return FeedSource(
+        adapter,
+        adapter.tier,
+        adapter.name,
+        CircuitBreaker(adapter.name),
+        no_retry_on,
+    )
+
+
+async def _no_sleep(d):
+    """Stand-in for asyncio.sleep so retry-path tests don't actually wait."""
+
+
+@pytest.mark.asyncio
+async def test_all_sources_consulted_and_merged():
+    a = StubAdapter("Q-Feeds", 2, iocs=[_ioc("1.1.1.1", source="Q-Feeds")])
+    b = StubAdapter("AbuseIPDB", 3, iocs=[_ioc("2.2.2.2", source="AbuseIPDB")])
+    result = await fan_out([_source(a), _source(b)])
+
+    assert result["record_count"] == 2
+    values = {i["value"] for i in result["iocs"]}
+    assert values == {"1.1.1.1", "2.2.2.2"}
+    assert set(result["sources_consulted"]) == {"Q-Feeds", "AbuseIPDB"}
+    assert result["sources_degraded"] == []
+    assert {e["status"] for e in result["coverage_ledger"]} == {"consulted"}
+
+
+@pytest.mark.asyncio
+async def test_cross_source_dedup_keeps_highest_confidence():
+    a = StubAdapter("Q-Feeds", 2, iocs=[_ioc("1.1.1.1", confidence="Low", source="Q-Feeds")])
+    b = StubAdapter("AbuseIPDB", 3, iocs=[_ioc("1.1.1.1", confidence="High", source="AbuseIPDB")])
+    result = await fan_out([_source(a), _source(b)])
+
+    assert result["record_count"] == 1
+    assert result["iocs"][0]["confidence"] == "High"
+    assert result["iocs"][0]["source"] == "AbuseIPDB"
+
+
+@pytest.mark.asyncio
+async def test_invalid_iocs_dropped_per_source():
+    # Missing required "source" field → dropped by validate_iocs.
+    bad = {"type": "IPv4", "value": "9.9.9.9", "confidence": "High"}
+    a = StubAdapter("Q-Feeds", 2, iocs=[bad, _ioc("1.1.1.1", source="Q-Feeds")])
+    result = await fan_out([_source(a)])
+
+    assert result["record_count"] == 1
+    assert result["iocs"][0]["value"] == "1.1.1.1"
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_with_data_is_partial():
+    a = StubAdapter(
+        "Q-Feeds", 2, iocs=[_ioc("1.1.1.1", source="Q-Feeds")], partial=["malware_domains"]
+    )
+    result = await fan_out([_source(a)])
+
+    ledger = result["coverage_ledger"][0]
+    assert ledger["status"] == "partial"
+    assert result["sources_consulted"] == []
+    assert result["sources_degraded"][0]["source"] == "Q-Feeds"
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_with_no_data_is_unverified():
+    a = StubAdapter("Q-Feeds", 2, iocs=[], partial=["malware_ip", "malware_domains"])
+    result = await fan_out([_source(a)])
+
+    assert result["coverage_ledger"][0]["status"] == "unverified"
+
+
+@pytest.mark.asyncio
+async def test_credential_error_degrades_not_crashes():
+    a = StubAdapter("VirusTotal", 2, raises=CredentialError("no key"))
+    b = StubAdapter("Q-Feeds", 2, iocs=[_ioc("1.1.1.1", source="Q-Feeds")])
+    result = await fan_out([_source(a), _source(b)])
+
+    # The configured source still returns data; the unconfigured one degrades.
+    assert result["record_count"] == 1
+    degraded = {d["source"]: d for d in result["sources_degraded"]}
+    assert "VirusTotal" in degraded
+    assert degraded["VirusTotal"]["status"] == "unverified"
+    assert degraded["VirusTotal"]["error"] == "CredentialError"
+    # Credential error is non-retryable: adapter called exactly once.
+    assert a.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_open_circuit_source_degrades():
+    a = StubAdapter("AbuseIPDB", 3, raises=RuntimeError("upstream 503"))
+    src = _source(a)
+    # Force the breaker open so guarded_fetch short-circuits before calling.
+    src.breaker._opened_at = src.breaker.clock()  # type: ignore[attr-defined]
+
+    result = await fan_out([src], retry_kwargs={"sleep": _no_sleep})
+
+    assert a.calls == 0
+    degraded = result["sources_degraded"][0]
+    assert degraded["source"] == "AbuseIPDB"
+    assert degraded["error"] == "circuit_open"
+
+
+@pytest.mark.asyncio
+async def test_transient_failure_surfaces_after_retries_exhausted():
+    a = StubAdapter("Q-Feeds", 2, raises=RuntimeError("timeout"))
+    result = await fan_out(
+        [_source(a)], retry_kwargs={"retries": 1, "jitter": False, "sleep": _no_sleep}
+    )
+
+    assert a.calls == 2  # retries=1 → 2 attempts
+    assert result["sources_degraded"][0]["error"] == "RuntimeError"
+    assert result["record_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_per_source_summary_excludes_raw_iocs():
+    a = StubAdapter("Q-Feeds", 2, iocs=[_ioc("1.1.1.1", source="Q-Feeds")])
+    result = await fan_out([_source(a)])
+
+    summary = result["per_source"][0]
+    assert "iocs" not in summary
+    assert summary["record_count"] == 1
+    assert summary["source"] == "Q-Feeds"

--- a/mcp/tests/test_resilience.py
+++ b/mcp/tests/test_resilience.py
@@ -1,0 +1,312 @@
+"""Tests for the resilience primitives: circuit breaker + backoff retry.
+
+Clock, sleep, and RNG are injected so the state machine and backoff schedule are
+deterministic with no real wall-clock waits.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from threat_intel_mcp.resilience import (
+    CircuitBreaker,
+    CircuitOpenError,
+    guarded_fetch,
+    retry_with_backoff,
+)
+
+
+class FakeClock:
+    """Manually advanced monotonic clock."""
+
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+# ---------------------------------------------------------------------------
+# CircuitBreaker state machine
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreaker:
+    def test_starts_closed_and_allows(self):
+        cb = CircuitBreaker("x", failure_threshold=3)
+        assert cb.state == "closed"
+        assert cb.allow() is True
+
+    def test_opens_after_threshold_consecutive_failures(self):
+        clock = FakeClock()
+        cb = CircuitBreaker("x", failure_threshold=3, clock=clock)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.state == "closed"  # 2 < 3
+        assert cb.allow() is True
+        cb.record_failure()
+        assert cb.state == "open"
+        assert cb.allow() is False
+
+    def test_success_resets_failure_count(self):
+        cb = CircuitBreaker("x", failure_threshold=3)
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_success()
+        cb.record_failure()
+        cb.record_failure()
+        # only 2 consecutive after the reset → still closed
+        assert cb.state == "closed"
+
+    def test_half_open_after_reset_timeout(self):
+        clock = FakeClock()
+        cb = CircuitBreaker("x", failure_threshold=1, reset_timeout=30.0, clock=clock)
+        cb.record_failure()
+        assert cb.state == "open"
+        assert cb.allow() is False
+        clock.advance(29.0)
+        assert cb.allow() is False
+        clock.advance(2.0)  # now 31s ≥ 30s
+        assert cb.allow() is True
+        assert cb.state == "half_open"
+
+    def test_half_open_success_closes(self):
+        clock = FakeClock()
+        cb = CircuitBreaker("x", failure_threshold=1, reset_timeout=10.0, clock=clock)
+        cb.record_failure()
+        clock.advance(11.0)
+        assert cb.allow() is True  # half-open
+        cb.record_success()
+        assert cb.state == "closed"
+        assert cb.allow() is True
+
+    def test_half_open_failure_reopens_and_restarts_cooldown(self):
+        clock = FakeClock()
+        cb = CircuitBreaker("x", failure_threshold=1, reset_timeout=10.0, clock=clock)
+        cb.record_failure()
+        clock.advance(11.0)
+        assert cb.allow() is True  # half-open trial permitted
+        cb.record_failure()  # trial fails
+        assert cb.state == "open"
+        assert cb.allow() is False
+        clock.advance(5.0)  # cooldown restarted, not yet elapsed
+        assert cb.allow() is False
+        clock.advance(6.0)
+        assert cb.allow() is True
+
+
+# ---------------------------------------------------------------------------
+# retry_with_backoff
+# ---------------------------------------------------------------------------
+
+
+class TestRetryWithBackoff:
+    @pytest.mark.asyncio
+    async def test_returns_on_first_success(self):
+        calls = 0
+
+        async def factory():
+            nonlocal calls
+            calls += 1
+            return "ok"
+
+        result = await retry_with_backoff(factory, retries=3)
+        assert result == "ok"
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_then_succeeds(self):
+        calls = 0
+        slept: list[float] = []
+
+        async def factory():
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise ValueError("transient")
+            return "ok"
+
+        async def fake_sleep(d):
+            slept.append(d)
+
+        result = await retry_with_backoff(
+            factory, retries=3, base_delay=1.0, jitter=False, sleep=fake_sleep
+        )
+        assert result == "ok"
+        assert calls == 3
+        # delays for attempt 0 and 1: 1.0, 2.0
+        assert slept == [1.0, 2.0]
+
+    @pytest.mark.asyncio
+    async def test_exhausts_and_raises_last(self):
+        calls = 0
+
+        async def factory():
+            nonlocal calls
+            calls += 1
+            raise RuntimeError(f"fail-{calls}")
+
+        async def fake_sleep(d):
+            pass
+
+        with pytest.raises(RuntimeError, match="fail-3"):
+            await retry_with_backoff(factory, retries=2, jitter=False, sleep=fake_sleep)
+        assert calls == 3  # retries + 1
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_raises_immediately(self):
+        calls = 0
+        slept: list[float] = []
+
+        async def factory():
+            nonlocal calls
+            calls += 1
+            raise KeyError("missing-key")
+
+        async def fake_sleep(d):
+            slept.append(d)
+
+        with pytest.raises(KeyError):
+            await retry_with_backoff(
+                factory,
+                retries=5,
+                no_retry_on=(KeyError,),
+                sleep=fake_sleep,
+            )
+        assert calls == 1
+        assert slept == []
+
+    @pytest.mark.asyncio
+    async def test_max_delay_caps_backoff(self):
+        slept: list[float] = []
+
+        async def factory():
+            raise ValueError("x")
+
+        async def fake_sleep(d):
+            slept.append(d)
+
+        with pytest.raises(ValueError):
+            await retry_with_backoff(
+                factory,
+                retries=5,
+                base_delay=1.0,
+                max_delay=3.0,
+                jitter=False,
+                sleep=fake_sleep,
+            )
+        # 1, 2, 3(capped from 4), 3(capped from 8), 3(capped from 16)
+        assert slept == [1.0, 2.0, 3.0, 3.0, 3.0]
+
+    @pytest.mark.asyncio
+    async def test_jitter_scales_into_half_to_full_range(self):
+        slept: list[float] = []
+
+        async def factory():
+            raise ValueError("x")
+
+        async def fake_sleep(d):
+            slept.append(d)
+
+        # rng fixed at 0.0 → jitter factor 0.5; base_delay 2.0 → first delay 1.0
+        with pytest.raises(ValueError):
+            await retry_with_backoff(
+                factory,
+                retries=1,
+                base_delay=2.0,
+                jitter=True,
+                sleep=fake_sleep,
+                rng=lambda: 0.0,
+            )
+        assert slept == [1.0]
+
+
+# ---------------------------------------------------------------------------
+# guarded_fetch
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, value):
+        self.value = value
+
+
+class FakeAdapter:
+    name = "Fake"
+    tier = 2
+
+    def __init__(self, *, fail_times: int = 0, exc: type[BaseException] = ValueError):
+        self.calls = 0
+        self.fail_times = fail_times
+        self.exc = exc
+
+    async def fetch(self, *, time_range: str, feed_types=None):
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise self.exc("boom")
+        return _FakeResult("data")
+
+
+async def _no_sleep(d):
+    pass
+
+
+class TestGuardedFetch:
+    @pytest.mark.asyncio
+    async def test_success_records_success(self):
+        cb = CircuitBreaker("Fake", failure_threshold=2)
+        adapter = FakeAdapter()
+        result = await guarded_fetch(
+            adapter, cb, time_range="7d", retries=0, sleep=_no_sleep
+        )
+        assert result.value == "data"
+        assert cb.state == "closed"
+
+    @pytest.mark.asyncio
+    async def test_failure_trips_breaker_after_threshold(self):
+        cb = CircuitBreaker("Fake", failure_threshold=2)
+        adapter = FakeAdapter(fail_times=99)
+
+        for _ in range(2):
+            with pytest.raises(ValueError):
+                await guarded_fetch(
+                    adapter, cb, time_range="7d", retries=0, sleep=_no_sleep
+                )
+        assert cb.state == "open"
+
+    @pytest.mark.asyncio
+    async def test_open_circuit_raises_without_calling_adapter(self):
+        cb = CircuitBreaker("Fake", failure_threshold=1)
+        adapter = FakeAdapter(fail_times=99)
+
+        with pytest.raises(ValueError):
+            await guarded_fetch(
+                adapter, cb, time_range="7d", retries=0, sleep=_no_sleep
+            )
+        assert cb.state == "open"
+        calls_before = adapter.calls
+        with pytest.raises(CircuitOpenError):
+            await guarded_fetch(
+                adapter, cb, time_range="7d", retries=0, sleep=_no_sleep
+            )
+        assert adapter.calls == calls_before  # adapter not invoked
+
+    @pytest.mark.asyncio
+    async def test_config_error_does_not_trip_breaker(self):
+        cb = CircuitBreaker("Fake", failure_threshold=1)
+        adapter = FakeAdapter(fail_times=99, exc=KeyError)
+
+        with pytest.raises(KeyError):
+            await guarded_fetch(
+                adapter,
+                cb,
+                time_range="7d",
+                no_retry_on=(KeyError,),
+                retries=3,
+                sleep=_no_sleep,
+            )
+        assert adapter.calls == 1  # not retried
+        assert cb.state == "closed"  # breaker untouched


### PR DESCRIPTION
## Summary

Implements the **async fan-out + resilience** slice of the `threat-intel-mcp` roadmap (issue #1, Phase 2/4). A single `fetch_all_iocs` call now queries **all four configured feeds concurrently** instead of serially, and one flaky/unconfigured feed degrades gracefully instead of failing the whole call.

- **`resilience.py`** (new): `CircuitBreaker` (closed → open → half-open state machine, injectable clock) and `retry_with_backoff` (exponential backoff + full jitter, injectable sleep/RNG, `no_retry_on` for config errors), composed by `guarded_fetch`. Credential/config errors are non-retryable and do **not** trip the breaker (a missing API key isn't an upstream-health signal).
- **`fanout.py`** (new): `FeedSource` + `fan_out()` runs every adapter concurrently via `asyncio.gather`, validates + dedupes per source, then merges into one deduplicated set (cross-source duplicates collapse to the highest-confidence copy). Failing / unconfigured / open-circuit sources surface as `unverified` Coverage-Ledger entries rather than raising.
- **`server.py`**: new `fetch_all_iocs` MCP tool wiring the 4 adapters into the fan-out, each with its own circuit breaker; audit-logged; `list_available_feeds` now advertises the aggregate tool; server instructions updated.
- **Docs**: `docs/architecture.md` gains the fan-out + resilience layer and the new tool (verified against the actual code, per the standing architecture-accuracy constraint); `mcp/README.md` status table, data-flow, and project structure updated. `pyproject.toml` `0.3.0` → `0.4.0`.

## Why this and not protocol breadth (gRPC/MQTT/etc.)

Building protocol adapters speculatively would require inventing broker/endpoint infrastructure with no real named feed behind it — a fabrication risk this repo explicitly forbids. The fan-out + resilience work is grounded entirely in the four adapters that already exist and delivers immediate value (latency near the slowest single feed instead of the sum; graceful degradation).

## Test plan

- [x] `cd mcp && python -m pytest tests/ -q` — **123 passed** (98 existing + 25 new)
- [x] `ruff check src/ tests/` — clean
- [x] New tests use injected clock/sleep/RNG and in-memory fake adapters: no real waits, no HTTP
- [x] Circuit breaker state machine: opens after threshold, half-opens after cooldown, closes on trial success, re-opens + restarts cooldown on trial failure
- [x] Fan-out: all-consulted merge, cross-source dedup keeps highest confidence, partial→`partial`/`unverified`, credential error degrades (called once, breaker untouched), open-circuit degrades without calling adapter, retries exhausted surfaces degraded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ)_