### PR TITLE
Add protocol credential bundles + adapter scaffolding (Phase 3, v0.5.0)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,8 @@ flowchart TD
 | MCP Server | `mcp/src/threat_intel_mcp/server.py` | FastMCP stdio server; exposes `qfeeds_fetch_iocs`, `abuseipdb_fetch_blocklist`, `virustotal_fetch_iocs`, `otx_fetch_iocs`, `fetch_all_iocs`, and `list_available_feeds` |
 | Fan-out | `mcp/src/threat_intel_mcp/fanout.py` | `fetch_all_iocs` backend: runs every configured adapter concurrently via `asyncio.gather`, validates + dedupes per source, merges into one deduplicated set, surfaces degraded sources to the Coverage Ledger |
 | Resilience | `mcp/src/threat_intel_mcp/resilience.py` | `CircuitBreaker` (closed/open/half-open) + `retry_with_backoff` (exponential backoff + jitter) wrapped by `guarded_fetch`; isolates one flaky feed from the rest |
+| Protocol credentials | `mcp/src/threat_intel_mcp/vault/protocols.py` | Typed, validated credential bundles for gRPC / MQTT / WebSocket / GraphQL feeds, loaded via the same `CredentialProvider` |
+| Protocol adapter base | `mcp/src/threat_intel_mcp/transports/base.py` | `ProtocolAdapter`: abstract bring-your-own-endpoint `SourceAdapter` (impl `_collect` + `_normalize`); ships **no live feed / no hardcoded endpoint**. See [protocol-adapters.md](protocol-adapters.md) |
 | EnvCredentialProvider | `mcp/src/threat_intel_mcp/vault/env.py` | Phase 1: reads `QFEEDS_API_KEY`, `ABUSEIPDB_API_KEY`, `VT_API_KEY`, and `OTX_API_KEY` from environment |
 | VaultCredentialProvider | `mcp/src/threat_intel_mcp/vault/` | Phase 2: reads credentials from HashiCorp Vault |
 | QFeedsAdapter | `mcp/src/threat_intel_mcp/adapters/qfeeds.py` | Fetches paginated malware IP and domain feeds; 20-min in-process cache |

--- a/docs/protocol-adapters.md
+++ b/docs/protocol-adapters.md
@@ -1,0 +1,105 @@
+# Protocol Adapters (gRPC / MQTT / WebSocket / GraphQL)
+
+Phase 3 of [issue #1](https://github.com/kj299/threat-intel/issues/1) adds secure
+credential storage and an adapter abstraction for non-REST intel transports, so
+the MCP server is "ready for diverse integrations" without changing how the four
+shipped REST feeds work.
+
+## What ships, and what does not
+
+**Ships (real, tested):**
+
+- **Credential bundles** — typed, validated multi-field credentials for each
+  protocol, retrieved through the same `CredentialProvider` used everywhere
+  (environment variables in dev, HashiCorp Vault in production). No new secret
+  store is introduced. See `mcp/src/threat_intel_mcp/vault/protocols.py`.
+- **`ProtocolAdapter` base** — an abstract `SourceAdapter` that standardises
+  timing, schema validation, deduplication, and `FetchResult` assembly. A
+  concrete feed implements only `_collect` (pull raw records over the transport)
+  and `_normalize` (map a raw record to an `ioc_network` dict). A
+  `ProtocolAdapter` drops straight into the existing concurrent fan-out and gets
+  the same circuit-breaker / retry treatment as the REST adapters. See
+  `mcp/src/threat_intel_mcp/transports/base.py`.
+
+**Does not ship (by design):**
+
+- **No live protocol feed, no hardcoded endpoint.** A concrete adapter is
+  configured entirely from operator-supplied credentials. Building an adapter
+  against an invented endpoint or a made-up response schema would violate this
+  repo's no-fabrication rule, so the live wiring (and the protocol client
+  library it needs) lands with the **first real, named feed** — not before.
+- **No protocol client dependencies.** `gql`, `websockets`, `paho-mqtt`, and
+  `grpcio` are *not* dependencies of `threat-intel-mcp`. A concrete adapter adds
+  the single library it needs.
+
+## Where credentials live
+
+Each protocol feed picks an `adapter` name (e.g. `chronicle_grpc`) and stores its
+fields under that name, following the existing `CredentialProvider` convention:
+
+| Mode | Path |
+|------|------|
+| Env (dev) | `{ADAPTER}_{KEY}` — e.g. `CHRONICLE_GRPC_TARGET` |
+| Vault (prod) | `{mount}/data/{adapter}/{key}` — e.g. `secret/data/chronicle_grpc/target` |
+
+Fields per protocol (required in **bold**):
+
+| Protocol | Fields |
+|----------|--------|
+| `graphql` | **`endpoint`**, `token`, `auth_header` (default `Authorization`), `auth_scheme` (default `Bearer`) |
+| `websocket` | **`url`**, `token`, `auth_header`, `auth_scheme`, `subprotocol` |
+| `mqtt` | **`host`**, `port` (default `8883`), `topic` (default `#`), `username`, `password`, `tls` (default `true`) |
+| `grpc` | **`target`** (`host:port`), `root_cert` (CA PEM), `client_cert` + `client_key` (mTLS pair — both or neither), `use_tls` (default `true`) |
+
+Credential errors name the *missing field*, never a retrieved value.
+
+## Worked example: a GraphQL intel feed
+
+```python
+from threat_intel_mcp.transports.base import ProtocolAdapter
+from threat_intel_mcp.vault.protocols import GraphQLCredentials
+# from gql import Client, gql                      # operator adds this dependency
+# from gql.transport.aiohttp import AIOHTTPTransport
+
+class MyGraphQLFeed(ProtocolAdapter):
+    name = "Acme Intel (GraphQL)"
+    tier = 2
+    protocol = "graphql"
+
+    def __init__(self, credentials):
+        # Pulls endpoint/token from env or Vault under adapter name "acme_graphql".
+        self._creds = GraphQLCredentials.from_provider(credentials, "acme_graphql")
+
+    async def _collect(self, *, time_range, feed_types):
+        # Open the operator's real endpoint and run the operator's real query.
+        # headers = {self._creds.auth_header: f"{self._creds.auth_scheme} {self._creds.token}"}
+        # transport = AIOHTTPTransport(url=self._creds.endpoint, headers=headers)
+        # async with Client(transport=transport) as session:
+        #     data = await session.execute(gql(MY_QUERY), {"since": time_range})
+        # return data["indicators"]
+        ...
+
+    def _normalize(self, raw):
+        # Map ONE record from this feed's real response shape to ioc_network.
+        if raw.get("kind") != "ipv4":
+            return None
+        return {
+            "type": "IPv4",
+            "value": raw["value"],
+            "confidence": raw.get("confidence", "Medium"),
+            "source": self.name,
+        }
+```
+
+Register it like any other source — wrap it in a `FeedSource` with its own
+`CircuitBreaker` and add it to the server's `_FEED_SOURCES` list so `fetch_all_iocs`
+picks it up. The base class handles validation, dedup, and `FetchResult`.
+
+## Why credentials, not adapters, are the deliverable here
+
+The original [issue #1](https://github.com/kj299/threat-intel/issues/1)
+acceptance criterion is *"securely store and retrieve credentials for REST APIs,
+gRPC endpoints, MQTT brokers, WebSockets, GraphQL services."* That is exactly
+what the credential bundles deliver and what the test suite covers. The transport
+abstraction makes plugging in a real feed a two-method exercise — but the feed
+itself only exists once you point it at a real endpoint you have access to.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -46,8 +46,10 @@ Claude receives ioc_network[] + coverage_ledger, cites sources (R2/R5)
 | Concurrent fan-out (`fetch_all_iocs`) | ✅ Phase 4 |
 | Circuit breakers + backoff retry per source | ✅ Phase 4 |
 | Partial-failure surfacing → Coverage Ledger | ✅ Phase 4 |
+| Protocol credential bundles (gRPC/MQTT/WebSocket/GraphQL) | ✅ Phase 3 |
+| `ProtocolAdapter` bring-your-own-endpoint base | ✅ Phase 3 |
 | Egress allowlist, response sanitization, rotation playbook | Phase 4 (pending) |
-| gRPC / MQTT / WebSocket / GraphQL adapters | Phase 3+ (needs named feeds) |
+| Live gRPC / MQTT / WebSocket / GraphQL **feeds** | needs a real named feed per protocol |
 
 ## Quick start
 
@@ -165,6 +167,22 @@ feed_integrations: [
 
 Claude will call the relevant `*_fetch_iocs` tools, blend live IOCs with its training-data knowledge, and cite each source in the Coverage Ledger (Appendix A) without marking findings as `unverified`.
 
+## Protocol feeds (gRPC / MQTT / WebSocket / GraphQL)
+
+Beyond the REST adapters, the server ships secure **credential storage** and a
+**bring-your-own-endpoint adapter base** for non-REST intel transports. Typed
+credential bundles (cert/key/CA for gRPC mTLS, host/port/topic for MQTT,
+URL/token for WebSocket, endpoint/token for GraphQL) load through the same
+env-var / Vault `CredentialProvider`, and `ProtocolAdapter` standardises
+validation, dedup, and `FetchResult` assembly so a concrete feed implements only
+`_collect` + `_normalize`.
+
+No live protocol feed (and no protocol client library) ships here: a concrete
+adapter is wired to a **real, operator-supplied endpoint** — inventing one would
+violate the repo's no-fabrication rule. See
+[`docs/protocol-adapters.md`](../docs/protocol-adapters.md) for the credential
+paths and a worked GraphQL example.
+
 ## Security notes
 
 - `EnvCredentialProvider` reads API keys from the environment. Suitable for local development only — env vars are visible in process listings and container inspection. Use `VaultCredentialProvider` for any non-local deployment.
@@ -180,7 +198,10 @@ src/threat_intel_mcp/
 │   ├── base.py            CredentialProvider Protocol + CredentialError
 │   ├── env.py             EnvCredentialProvider (dev only)
 │   ├── hashicorp.py       VaultCredentialProvider (AppRole + KV v2)
-│   └── factory.py         credential_provider_from_env() selector
+│   ├── factory.py         credential_provider_from_env() selector
+│   └── protocols.py       Typed gRPC/MQTT/WebSocket/GraphQL credential bundles
+├── transports/
+│   └── base.py            ProtocolAdapter: bring-your-own-endpoint base class
 ├── adapters/
 │   ├── base.py            SourceAdapter Protocol + FetchResult dataclass
 │   ├── qfeeds.py          Q-Feeds REST adapter (20-min cache)
@@ -198,6 +219,8 @@ tests/
 ├── test_otx.py            OTX adapter tests
 ├── test_fanout.py         Fan-out merge / dedup / degrade tests (fake adapters)
 ├── test_resilience.py     Circuit breaker + backoff retry tests
+├── test_protocol_credentials.py  gRPC/MQTT/WS/GraphQL credential bundle tests
+├── test_protocol_adapter.py      ProtocolAdapter base + fan-out integration tests
 ├── test_normalize.py      Normaliser / validator tests
 └── test_vault.py          Vault provider + factory tests (hvac mocked)
 ```

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "threat-intel-mcp"
-version = "0.4.0"
+version = "0.5.0"
 description = "MCP server that delivers live threat intelligence feeds to Claude, normalised to the threat-intel skill schema"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/mcp/src/threat_intel_mcp/transports/__init__.py
+++ b/mcp/src/threat_intel_mcp/transports/__init__.py
@@ -1,0 +1,11 @@
+"""Protocol transport scaffolding for non-REST intel feeds (Phase 3).
+
+Bring-your-own-endpoint base classes for gRPC, MQTT, WebSocket, and GraphQL
+sources. This package ships no live feed and no hardcoded endpoint — a concrete
+adapter is configured entirely from operator-supplied credentials (see
+``threat_intel_mcp.vault.protocols``).
+"""
+
+from .base import ProtocolAdapter
+
+__all__ = ["ProtocolAdapter"]

--- a/mcp/src/threat_intel_mcp/transports/base.py
+++ b/mcp/src/threat_intel_mcp/transports/base.py
@@ -1,0 +1,92 @@
+"""Bring-your-own-endpoint protocol adapter scaffolding.
+
+A :class:`ProtocolAdapter` is an abstract :class:`SourceAdapter` for a non-REST
+transport (gRPC, MQTT, WebSocket, GraphQL). It standardises timing, schema
+validation, deduplication, and ``FetchResult`` assembly so a concrete feed only
+implements two protocol-specific things:
+
+* :meth:`_collect` — pull raw records over the transport, and
+* :meth:`_normalize` — map one raw record to an ``ioc_network`` dict.
+
+A ``ProtocolAdapter`` subclass satisfies the ``SourceAdapter`` protocol, so it
+drops straight into the existing fan-out (:mod:`threat_intel_mcp.fanout`) and
+gets the same circuit-breaker / retry treatment as the REST adapters.
+
+This module intentionally contains **no live feed and no hardcoded endpoint** —
+a concrete adapter is configured entirely from operator-supplied credentials
+(see :mod:`threat_intel_mcp.vault.protocols`). The protocol client libraries
+(``gql``, ``websockets``, ``paho-mqtt``, ``grpcio``) are deliberately **not**
+dependencies of this package; a concrete adapter adds the one it needs. Building
+adapters against invented endpoints/response shapes would violate the repo's
+no-fabrication rule, so the live wiring lands with the first real feed.
+"""
+
+from __future__ import annotations
+
+import time
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from typing import Any
+
+from ..adapters.base import FetchResult
+from ..normalize import deduplicate_iocs, validate_iocs
+
+
+class ProtocolAdapter(ABC):
+    """Abstract base for a protocol-transport intel feed.
+
+    Subclasses set ``name``, ``tier``, and ``protocol`` (one of the keys in
+    ``vault.protocols.PROTOCOL_CREDENTIALS``) and implement :meth:`_collect` and
+    :meth:`_normalize`. The base supplies a complete :meth:`fetch` that validates
+    and deduplicates output and returns a ``FetchResult`` identical in shape to
+    the REST adapters'.
+    """
+
+    name: str = "protocol-adapter"
+    tier: int = 9
+    protocol: str = ""
+
+    @abstractmethod
+    async def _collect(
+        self, *, time_range: str, feed_types: list[str] | None
+    ) -> list[Any]:
+        """Pull raw records from the upstream transport. Implemented per feed.
+
+        Should return a list of raw, un-normalised records (dicts, protobuf
+        messages, decoded frames — whatever the transport yields). Network and
+        auth errors should propagate; the fan-out's circuit breaker handles them.
+        """
+
+    @abstractmethod
+    def _normalize(self, raw: Any) -> dict[str, Any] | None:
+        """Map one raw record to an ``ioc_network`` dict, or ``None`` to skip.
+
+        Must set at least ``type``, ``value``, ``confidence``, and ``source``.
+        Records that cannot be mapped (wrong indicator type, missing fields)
+        should return ``None`` rather than raising.
+        """
+
+    async def fetch(
+        self, *, time_range: str = "7d", feed_types: list[str] | None = None
+    ) -> FetchResult:
+        """Collect, normalise, validate, and deduplicate into a ``FetchResult``."""
+        t0 = time.monotonic()
+        raw_records = await self._collect(time_range=time_range, feed_types=feed_types)
+        normalized = [
+            ioc
+            for raw in raw_records
+            if (ioc := self._normalize(raw)) is not None
+        ]
+        deduped = deduplicate_iocs(validate_iocs(normalized))
+        latency_ms = round((time.monotonic() - t0) * 1000, 1)
+
+        return FetchResult(
+            iocs=deduped,
+            source=self.name,
+            tier=self.tier,
+            retrieved_at=datetime.now(timezone.utc).isoformat(),
+            record_count=len(deduped),
+            latency_ms=latency_ms,
+            feed_types_fetched=feed_types or ([self.protocol] if self.protocol else []),
+            partial_failure=[],
+        )

--- a/mcp/src/threat_intel_mcp/vault/protocols.py
+++ b/mcp/src/threat_intel_mcp/vault/protocols.py
@@ -1,0 +1,207 @@
+"""Typed multi-field credential bundles for protocol-based intel feeds.
+
+Phase 3 of issue #1: securely store and retrieve credentials for gRPC, MQTT,
+WebSocket, and GraphQL intel sources alongside the existing REST feeds. Each
+bundle is assembled from the same :class:`CredentialProvider` used everywhere
+else (environment variables in dev, HashiCorp Vault in production), so no new
+secret store is introduced — only typed accessors with required-field validation.
+
+Storage convention (inherited from the CredentialProvider contract)::
+
+    env:    {ADAPTER}_{KEY}                e.g. CHRONICLE_GRPC_TARGET
+    Vault:  {mount}/data/{adapter}/{key}   e.g. secret/data/chronicle_grpc/target
+
+Where ``adapter`` is a name you choose per feed (e.g. ``chronicle_grpc``) and
+``key`` is a field below (``target``, ``host``, ``endpoint``, ``token`` …).
+
+No secret value is ever logged or placed in an exception message — errors name
+the *missing key*, never the *retrieved value*.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import CredentialError, CredentialProvider
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _require(provider: CredentialProvider, adapter: str, key: str) -> str:
+    """Fetch a mandatory credential field, normalising the not-found error."""
+    try:
+        value = provider.get(adapter, key)
+    except (CredentialError, KeyError):
+        raise CredentialError(
+            f"Missing required credential '{key}' for protocol feed '{adapter}'. "
+            f"Store it as env {adapter.upper()}_{key.upper()} or Vault "
+            f"{adapter}/{key}."
+        ) from None
+    if not value:
+        raise CredentialError(
+            f"Credential '{key}' for protocol feed '{adapter}' is present but empty."
+        )
+    return value
+
+
+def _optional(
+    provider: CredentialProvider, adapter: str, key: str, default: str | None = None
+) -> str | None:
+    """Fetch an optional credential field, returning ``default`` if absent/empty."""
+    try:
+        value = provider.get(adapter, key)
+    except (CredentialError, KeyError):
+        return default
+    return value or default
+
+
+def _as_int(value: str, adapter: str, key: str) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise CredentialError(
+            f"Credential '{key}' for protocol feed '{adapter}' must be an integer."
+        ) from None
+
+
+def _as_bool(value: str | None, default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in _TRUTHY
+
+
+@dataclass(frozen=True)
+class GraphQLCredentials:
+    """Credentials for a GraphQL intel source (operator-supplied endpoint)."""
+
+    endpoint: str
+    token: str | None = None
+    auth_header: str = "Authorization"
+    auth_scheme: str = "Bearer"
+
+    @classmethod
+    def from_provider(
+        cls, provider: CredentialProvider, adapter: str
+    ) -> GraphQLCredentials:
+        return cls(
+            endpoint=_require(provider, adapter, "endpoint"),
+            token=_optional(provider, adapter, "token"),
+            auth_header=_optional(provider, adapter, "auth_header", "Authorization")
+            or "Authorization",
+            auth_scheme=_optional(provider, adapter, "auth_scheme", "Bearer")
+            or "Bearer",
+        )
+
+
+@dataclass(frozen=True)
+class WebSocketCredentials:
+    """Credentials for a WebSocket streaming intel source."""
+
+    url: str
+    token: str | None = None
+    auth_header: str = "Authorization"
+    auth_scheme: str = "Bearer"
+    subprotocol: str | None = None
+
+    @classmethod
+    def from_provider(
+        cls, provider: CredentialProvider, adapter: str
+    ) -> WebSocketCredentials:
+        return cls(
+            url=_require(provider, adapter, "url"),
+            token=_optional(provider, adapter, "token"),
+            auth_header=_optional(provider, adapter, "auth_header", "Authorization")
+            or "Authorization",
+            auth_scheme=_optional(provider, adapter, "auth_scheme", "Bearer")
+            or "Bearer",
+            subprotocol=_optional(provider, adapter, "subprotocol"),
+        )
+
+
+@dataclass(frozen=True)
+class MQTTCredentials:
+    """Credentials for an MQTT broker delivering real-time intel."""
+
+    host: str
+    port: int = 8883
+    topic: str = "#"
+    username: str | None = None
+    password: str | None = None
+    tls: bool = True
+
+    @classmethod
+    def from_provider(
+        cls, provider: CredentialProvider, adapter: str
+    ) -> MQTTCredentials:
+        host = _require(provider, adapter, "host")
+        port = _as_int(_optional(provider, adapter, "port", "8883") or "8883", adapter, "port")
+        return cls(
+            host=host,
+            port=port,
+            topic=_optional(provider, adapter, "topic", "#") or "#",
+            username=_optional(provider, adapter, "username"),
+            password=_optional(provider, adapter, "password"),
+            tls=_as_bool(_optional(provider, adapter, "tls"), default=True),
+        )
+
+
+@dataclass(frozen=True)
+class GRPCCredentials:
+    """Credentials for a gRPC intel endpoint, with optional mTLS materials.
+
+    ``client_cert`` and ``client_key`` form an mTLS pair: supply both or neither.
+    ``root_cert`` (CA PEM) is optional and used to verify the server certificate.
+    """
+
+    target: str  # host:port
+    root_cert: str | None = None
+    client_cert: str | None = None
+    client_key: str | None = None
+    use_tls: bool = True
+
+    def __post_init__(self) -> None:
+        if bool(self.client_cert) != bool(self.client_key):
+            raise CredentialError(
+                "gRPC mTLS requires both 'client_cert' and 'client_key' "
+                "(or neither). Only one was provided."
+            )
+
+    @classmethod
+    def from_provider(
+        cls, provider: CredentialProvider, adapter: str
+    ) -> GRPCCredentials:
+        return cls(
+            target=_require(provider, adapter, "target"),
+            root_cert=_optional(provider, adapter, "root_cert"),
+            client_cert=_optional(provider, adapter, "client_cert"),
+            client_key=_optional(provider, adapter, "client_key"),
+            use_tls=_as_bool(_optional(provider, adapter, "use_tls"), default=True),
+        )
+
+
+# Registry mapping a protocol name to its credential bundle class.
+PROTOCOL_CREDENTIALS: dict[str, type] = {
+    "graphql": GraphQLCredentials,
+    "websocket": WebSocketCredentials,
+    "mqtt": MQTTCredentials,
+    "grpc": GRPCCredentials,
+}
+
+
+def load_protocol_credentials(
+    protocol: str, provider: CredentialProvider, adapter: str
+):
+    """Load and validate the credential bundle for ``protocol`` and ``adapter``.
+
+    Raises:
+        CredentialError: if the protocol is unsupported or a required field is
+            missing / malformed.
+    """
+    try:
+        bundle_cls = PROTOCOL_CREDENTIALS[protocol]
+    except KeyError:
+        raise CredentialError(
+            f"Unsupported protocol '{protocol}'. "
+            f"Supported: {sorted(PROTOCOL_CREDENTIALS)}."
+        ) from None
+    return bundle_cls.from_provider(provider, adapter)

--- a/mcp/tests/test_protocol_adapter.py
+++ b/mcp/tests/test_protocol_adapter.py
@@ -1,0 +1,104 @@
+"""Tests for the ProtocolAdapter scaffolding (Phase 3).
+
+Uses a fake in-memory concrete subclass (no transport, no heavy deps) to prove
+the base handles normalisation, validation, dedup, and FetchResult assembly, and
+that a ProtocolAdapter drops into the existing fan-out machinery unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from threat_intel_mcp.adapters.base import FetchResult, SourceAdapter
+from threat_intel_mcp.fanout import FeedSource, fan_out
+from threat_intel_mcp.resilience import CircuitBreaker
+from threat_intel_mcp.transports.base import ProtocolAdapter
+
+
+class FakeGraphQLAdapter(ProtocolAdapter):
+    """A concrete ProtocolAdapter whose 'transport' is a canned record list."""
+
+    name = "FakeGraphQL"
+    tier = 2
+    protocol = "graphql"
+
+    def __init__(self, records):
+        self._records = records
+        self.collect_calls = 0
+
+    async def _collect(self, *, time_range, feed_types):
+        self.collect_calls += 1
+        return self._records
+
+    def _normalize(self, raw):
+        # raw is {"ip": ..., "score": ...}; skip records without an ip.
+        ip = raw.get("ip")
+        if not ip:
+            return None
+        return {
+            "type": "IPv4",
+            "value": ip,
+            "confidence": raw.get("confidence", "Medium"),
+            "source": self.name,
+        }
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_fetchresult_with_normalized_iocs():
+    adapter = FakeGraphQLAdapter(
+        [{"ip": "1.1.1.1", "confidence": "High"}, {"ip": "2.2.2.2"}]
+    )
+    result = await adapter.fetch(time_range="7d")
+
+    assert isinstance(result, FetchResult)
+    assert result.source == "FakeGraphQL"
+    assert result.tier == 2
+    assert result.record_count == 2
+    assert {i["value"] for i in result.iocs} == {"1.1.1.1", "2.2.2.2"}
+    assert result.feed_types_fetched == ["graphql"]
+
+
+@pytest.mark.asyncio
+async def test_normalize_none_records_skipped():
+    adapter = FakeGraphQLAdapter([{"ip": "1.1.1.1"}, {"notanip": "x"}, {"ip": ""}])
+    result = await adapter.fetch()
+    assert result.record_count == 1
+    assert result.iocs[0]["value"] == "1.1.1.1"
+
+
+@pytest.mark.asyncio
+async def test_invalid_iocs_dropped_by_validation():
+    # "Bogus" is not a valid ioc_network type → dropped by validate_iocs.
+    class BadAdapter(FakeGraphQLAdapter):
+        def _normalize(self, raw):
+            return {"type": "Bogus", "value": raw["ip"], "confidence": "High",
+                    "source": self.name}
+
+    result = await BadAdapter([{"ip": "1.1.1.1"}]).fetch()
+    assert result.record_count == 0
+
+
+@pytest.mark.asyncio
+async def test_cross_record_dedup_keeps_highest_confidence():
+    adapter = FakeGraphQLAdapter(
+        [{"ip": "1.1.1.1", "confidence": "Low"}, {"ip": "1.1.1.1", "confidence": "High"}]
+    )
+    result = await adapter.fetch()
+    assert result.record_count == 1
+    assert result.iocs[0]["confidence"] == "High"
+
+
+def test_protocol_adapter_satisfies_source_adapter_protocol():
+    adapter = FakeGraphQLAdapter([])
+    assert isinstance(adapter, SourceAdapter)
+
+
+@pytest.mark.asyncio
+async def test_drops_into_fanout_unchanged():
+    adapter = FakeGraphQLAdapter([{"ip": "9.9.9.9", "confidence": "High"}])
+    source = FeedSource(adapter, adapter.tier, adapter.name, CircuitBreaker(adapter.name))
+    result = await fan_out([source])
+
+    assert result["record_count"] == 1
+    assert result["sources_consulted"] == ["FakeGraphQL"]
+    assert result["iocs"][0]["value"] == "9.9.9.9"

--- a/mcp/tests/test_protocol_credentials.py
+++ b/mcp/tests/test_protocol_credentials.py
@@ -1,0 +1,198 @@
+"""Tests for the protocol credential bundles (Phase 3).
+
+Verifies required/optional field handling, type coercion, mTLS pairing, and that
+error messages name the missing key — never a secret value.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from threat_intel_mcp.vault.base import CredentialError
+from threat_intel_mcp.vault.protocols import (
+    GRPCCredentials,
+    GraphQLCredentials,
+    MQTTCredentials,
+    WebSocketCredentials,
+    load_protocol_credentials,
+)
+
+
+class DictCredentials:
+    """In-memory CredentialProvider backed by a {(adapter, key): value} dict."""
+
+    def __init__(self, values: dict[tuple[str, str], str]):
+        self._values = values
+
+    def get(self, adapter_name: str, key: str) -> str:
+        try:
+            return self._values[(adapter_name, key)]
+        except KeyError:
+            raise CredentialError(f"no such secret {adapter_name}/{key}") from None
+
+
+# ---------------------------------------------------------------------------
+# GraphQL
+# ---------------------------------------------------------------------------
+
+
+class TestGraphQL:
+    def test_minimal_requires_only_endpoint(self):
+        creds = DictCredentials({("rf_graphql", "endpoint"): "https://example/graphql"})
+        bundle = GraphQLCredentials.from_provider(creds, "rf_graphql")
+        assert bundle.endpoint == "https://example/graphql"
+        assert bundle.token is None
+        assert bundle.auth_header == "Authorization"
+        assert bundle.auth_scheme == "Bearer"
+
+    def test_missing_endpoint_raises_naming_the_key(self):
+        creds = DictCredentials({("rf_graphql", "token"): "secret-token-value"})
+        with pytest.raises(CredentialError) as exc:
+            GraphQLCredentials.from_provider(creds, "rf_graphql")
+        msg = str(exc.value)
+        assert "endpoint" in msg
+        assert "secret-token-value" not in msg  # never leak a value
+
+    def test_optional_overrides(self):
+        creds = DictCredentials(
+            {
+                ("g", "endpoint"): "https://e/graphql",
+                ("g", "token"): "t",
+                ("g", "auth_header"): "X-API-Key",
+                ("g", "auth_scheme"): "Token",
+            }
+        )
+        bundle = GraphQLCredentials.from_provider(creds, "g")
+        assert bundle.token == "t"
+        assert bundle.auth_header == "X-API-Key"
+        assert bundle.auth_scheme == "Token"
+
+    def test_empty_required_value_rejected(self):
+        creds = DictCredentials({("g", "endpoint"): ""})
+        with pytest.raises(CredentialError, match="empty"):
+            GraphQLCredentials.from_provider(creds, "g")
+
+
+# ---------------------------------------------------------------------------
+# WebSocket
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocket:
+    def test_minimal(self):
+        creds = DictCredentials({("ws", "url"): "wss://feed/stream"})
+        bundle = WebSocketCredentials.from_provider(creds, "ws")
+        assert bundle.url == "wss://feed/stream"
+        assert bundle.subprotocol is None
+
+    def test_missing_url_raises(self):
+        creds = DictCredentials({})
+        with pytest.raises(CredentialError, match="url"):
+            WebSocketCredentials.from_provider(creds, "ws")
+
+    def test_subprotocol_carried(self):
+        creds = DictCredentials(
+            {("ws", "url"): "wss://feed", ("ws", "subprotocol"): "stix"}
+        )
+        assert WebSocketCredentials.from_provider(creds, "ws").subprotocol == "stix"
+
+
+# ---------------------------------------------------------------------------
+# MQTT
+# ---------------------------------------------------------------------------
+
+
+class TestMQTT:
+    def test_defaults(self):
+        creds = DictCredentials({("mq", "host"): "broker.example"})
+        bundle = MQTTCredentials.from_provider(creds, "mq")
+        assert bundle.host == "broker.example"
+        assert bundle.port == 8883
+        assert bundle.topic == "#"
+        assert bundle.tls is True
+        assert bundle.username is None
+
+    def test_explicit_values(self):
+        creds = DictCredentials(
+            {
+                ("mq", "host"): "broker",
+                ("mq", "port"): "1883",
+                ("mq", "topic"): "intel/iocs",
+                ("mq", "username"): "u",
+                ("mq", "password"): "p",
+                ("mq", "tls"): "false",
+            }
+        )
+        bundle = MQTTCredentials.from_provider(creds, "mq")
+        assert bundle.port == 1883
+        assert bundle.topic == "intel/iocs"
+        assert bundle.username == "u"
+        assert bundle.tls is False
+
+    def test_bad_port_raises(self):
+        creds = DictCredentials({("mq", "host"): "b", ("mq", "port"): "notaport"})
+        with pytest.raises(CredentialError, match="port"):
+            MQTTCredentials.from_provider(creds, "mq")
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [("true", True), ("1", True), ("YES", True), ("on", True),
+         ("false", False), ("0", False), ("no", False)],
+    )
+    def test_tls_parsing(self, raw, expected):
+        creds = DictCredentials({("mq", "host"): "b", ("mq", "tls"): raw})
+        assert MQTTCredentials.from_provider(creds, "mq").tls is expected
+
+
+# ---------------------------------------------------------------------------
+# gRPC
+# ---------------------------------------------------------------------------
+
+
+class TestGRPC:
+    def test_minimal_target_only(self):
+        creds = DictCredentials({("g", "target"): "host:443"})
+        bundle = GRPCCredentials.from_provider(creds, "g")
+        assert bundle.target == "host:443"
+        assert bundle.use_tls is True
+        assert bundle.client_cert is None
+
+    def test_missing_target_raises(self):
+        with pytest.raises(CredentialError, match="target"):
+            GRPCCredentials.from_provider(DictCredentials({}), "g")
+
+    def test_full_mtls_pair(self):
+        creds = DictCredentials(
+            {
+                ("g", "target"): "host:443",
+                ("g", "root_cert"): "CA-PEM",
+                ("g", "client_cert"): "CERT-PEM",
+                ("g", "client_key"): "KEY-PEM",
+            }
+        )
+        bundle = GRPCCredentials.from_provider(creds, "g")
+        assert bundle.client_cert == "CERT-PEM"
+        assert bundle.client_key == "KEY-PEM"
+
+    def test_half_mtls_pair_rejected(self):
+        creds = DictCredentials(
+            {("g", "target"): "host:443", ("g", "client_cert"): "CERT-PEM"}
+        )
+        with pytest.raises(CredentialError, match="mTLS"):
+            GRPCCredentials.from_provider(creds, "g")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    def test_load_known_protocol(self):
+        creds = DictCredentials({("mq", "host"): "broker"})
+        bundle = load_protocol_credentials("mqtt", creds, "mq")
+        assert isinstance(bundle, MQTTCredentials)
+
+    def test_unsupported_protocol_raises(self):
+        with pytest.raises(CredentialError, match="Unsupported protocol"):
+            load_protocol_credentials("smtp", DictCredentials({}), "x")


### PR DESCRIPTION
## Summary

Implements the credential-storage + adapter-abstraction core of **issue #1 Phase 3 (protocol breadth)** for gRPC / MQTT / WebSocket / GraphQL — which is also the issue's *primary* acceptance criterion: _"securely store and retrieve credentials for REST APIs, gRPC endpoints, MQTT brokers, WebSockets, GraphQL services."_

- **`vault/protocols.py`** (new): typed, frozen credential bundles — `GraphQLCredentials`, `WebSocketCredentials`, `MQTTCredentials`, `GRPCCredentials` — loaded via the **existing** `CredentialProvider` (env vars or HashiCorp Vault, no new secret store) with required-field validation, int/bool coercion, and gRPC mTLS cert/key pairing. Error messages name the *missing key*, never a retrieved value. `load_protocol_credentials()` dispatches by protocol name.
- **`transports/base.py`** (new): `ProtocolAdapter` — an abstract bring-your-own-endpoint `SourceAdapter` that standardises timing, schema validation, dedup, and `FetchResult` assembly. A concrete feed implements only `_collect` + `_normalize` and drops straight into the existing concurrent fan-out (same circuit-breaker / retry treatment as the REST adapters).
- **`docs/protocol-adapters.md`** (new): credential storage paths per protocol (env + Vault), a worked GraphQL example, and the scope note below.

## Scope: why credentials + abstraction, not live adapters

This deliberately ships **no live protocol feed, no hardcoded endpoint, and no protocol client library** (`gql`/`websockets`/`paho-mqtt`/`grpcio` are not added as deps). Building a protocol *feed* requires a real, named source with a real endpoint and response schema — inventing those would violate this repo's no-fabrication rule. So a concrete adapter wires to an **operator-supplied** endpoint, and the live wiring + the one client library it needs land with the first real feed. The honest, testable deliverable here is the credential bundles (the acceptance criterion) plus the two-method extension contract.

## Test plan

- [x] `cd mcp && python -m pytest tests/ -q` — **152 passed** (123 prior + 29 new)
- [x] `ruff check src/ tests/` — clean
- [x] Credential bundles: required/optional fields, empty-value rejection, MQTT port/tls coercion, gRPC mTLS pair validation (half-pair rejected), unsupported-protocol dispatch, and no-secret-in-error assertion
- [x] `ProtocolAdapter`: fake subclass proven end-to-end through `fetch()` (normalize/skip/validate-drop/dedup) **and** through `fan_out()` — confirming a protocol adapter satisfies `SourceAdapter` and integrates with the existing fan-out unchanged

Progress comment posted to issue #1: https://github.com/kj299/threat-intel/issues/1#issuecomment-4828177183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ)_