### PR TITLE
Fix High review findings: vault docs, dead resilience layer, truncation fabrication (v0.7.0)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -130,11 +130,15 @@ Secrets must be stored in KV v2 under:
 The default mount point is `secret`. Examples:
 
 ```bash
-vault kv put secret/qfeeds    api_key=<your-qfeeds-key>
-vault kv put secret/abuseipdb api_key=<your-abuseipdb-key>
-vault kv put secret/virustotal api_key=<your-vt-key>
-vault kv put secret/otx       api_key=<your-otx-key>
+vault kv put secret/qfeeds/api_key     api_key=<your-qfeeds-key>
+vault kv put secret/abuseipdb/api_key  api_key=<your-abuseipdb-key>
+vault kv put secret/virustotal/api_key api_key=<your-vt-key>
+vault kv put secret/otx/api_key        api_key=<your-otx-key>
 ```
+
+Note the path is `{adapter}/{key}` and the field inside the secret repeats the
+key name — the provider reads field `api_key` from the secret at
+`secret/data/{adapter}/api_key`.
 
 ### Claude Code MCP config (Vault mode)
 
@@ -197,7 +201,7 @@ paths and a worked GraphQL example.
 Rotate a feed's credential without downtime:
 
 1. **Issue** the new key in the provider's console (most allow two live keys during overlap).
-2. **Store** it: env mode — update the env var and restart the server; Vault mode — `vault kv put secret/<adapter> api_key=<new-key>` (KV v2 keeps the prior version, so rollback is `vault kv rollback`). Multi-field protocol creds rotate the same way, key by key.
+2. **Store** it: env mode — update the env var and restart the server; Vault mode — `vault kv put secret/<adapter>/api_key api_key=<new-key>` (KV v2 keeps the prior version, so rollback is `vault kv rollback -mount=secret <adapter>/api_key`). Multi-field protocol creds rotate the same way, key by key.
 3. **Verify** with `list_available_feeds` (`credential_configured: true`) and a `fetch_all_iocs` call — the rotated source should return `consulted`, not `unverified`.
 4. **Revoke** the old key once traffic is confirmed on the new one.
 

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "threat-intel-mcp"
-version = "0.6.0"
+version = "0.7.0"
 description = "MCP server that delivers live threat intelligence feeds to Claude, normalised to the threat-intel skill schema"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/mcp/src/threat_intel_mcp/adapters/otx.py
+++ b/mcp/src/threat_intel_mcp/adapters/otx.py
@@ -166,18 +166,26 @@ class OTXAdapter:
             FetchResult with normalised ioc_network objects.
         """
         t_start = time.monotonic()
-        failed: list[str] = []
 
         since_dt = _parse_time_range(time_range)
         since_iso = since_dt.strftime("%Y-%m-%dT%H:%M:%S")
 
+        # OTX has a single feed, so any upstream failure is a total failure.
+        # Propagate it: the caller's retry/circuit-breaker layer owns failure
+        # policy, and swallowing here would blind it (issue #56).
         try:
             async with self._make_client() as client:
                 iocs = await self._fetch_subscribed(client, since_iso)
         except Exception as exc:
-            logger.warning("OTX fetch failed: %s", exc)
-            failed.append("subscribed")
-            iocs = []
+            log_tool_call(
+                "otx_fetch_iocs",
+                {"time_range": time_range, "modified_since": since_iso},
+                record_count=0,
+                latency_ms=(time.monotonic() - t_start) * 1000,
+                status="error",
+                error=type(exc).__name__,
+            )
+            raise
 
         latency_ms = (time.monotonic() - t_start) * 1000
 
@@ -186,8 +194,7 @@ class OTXAdapter:
             {"time_range": time_range, "modified_since": since_iso},
             record_count=len(iocs),
             latency_ms=latency_ms,
-            status="partial" if failed else "ok",
-            error=f"failed: {failed}" if failed else None,
+            status="ok",
         )
 
         return FetchResult(
@@ -197,8 +204,8 @@ class OTXAdapter:
             retrieved_at=datetime.now(timezone.utc).isoformat(),
             record_count=len(iocs),
             latency_ms=round(latency_ms, 1),
-            feed_types_fetched=[] if failed else ["subscribed"],
-            partial_failure=failed,
+            feed_types_fetched=["subscribed"],
+            partial_failure=[],
         )
 
     async def _fetch_subscribed(

--- a/mcp/src/threat_intel_mcp/adapters/qfeeds.py
+++ b/mcp/src/threat_intel_mcp/adapters/qfeeds.py
@@ -98,6 +98,7 @@ class QFeedsAdapter:
         t_start = time.monotonic()
         all_iocs: list[dict[str, Any]] = []
         failed: list[str] = []
+        last_exc: Exception | None = None
 
         async with self._make_client() as client:
             tasks = {
@@ -113,6 +114,21 @@ class QFeedsAdapter:
                         "Q-Feeds feed_type=%s fetch failed: %s", feed_type, exc
                     )
                     failed.append(feed_type)
+                    last_exc = exc
+
+        # Every requested feed type failed: this is a total failure, not a
+        # partial result. Propagate so the caller's retry/circuit-breaker layer
+        # can act on it (issue #56). Partial results still return below.
+        if last_exc is not None and len(failed) == len(requested):
+            log_tool_call(
+                "qfeeds_fetch_iocs",
+                {"time_range": time_range, "feed_types": requested},
+                record_count=0,
+                latency_ms=(time.monotonic() - t_start) * 1000,
+                status="error",
+                error=type(last_exc).__name__,
+            )
+            raise last_exc
 
         latency_ms = (time.monotonic() - t_start) * 1000
         fetched = [t for t in requested if t not in failed]

--- a/mcp/src/threat_intel_mcp/adapters/virustotal.py
+++ b/mcp/src/threat_intel_mcp/adapters/virustotal.py
@@ -168,6 +168,7 @@ class VirusTotalAdapter:
         t_start = time.monotonic()
         all_iocs: list[dict[str, Any]] = []
         failed: list[str] = []
+        last_exc: Exception | None = None
 
         async with self._make_client() as client:
             # Fetch feed types sequentially (rate limit enforced inside _fetch_feed).
@@ -180,6 +181,21 @@ class VirusTotalAdapter:
                         "VirusTotal feed_type=%s fetch failed: %s", feed_type, exc
                     )
                     failed.append(feed_type)
+                    last_exc = exc
+
+        # Every requested feed type failed: total failure — propagate so the
+        # caller's retry/circuit-breaker layer can act on it (issue #56).
+        # Partial results still return below.
+        if last_exc is not None and len(failed) == len(requested):
+            log_tool_call(
+                "virustotal_fetch_iocs",
+                {"time_range": time_range, "feed_types": requested},
+                record_count=0,
+                latency_ms=(time.monotonic() - t_start) * 1000,
+                status="error",
+                error=type(last_exc).__name__,
+            )
+            raise last_exc
 
         latency_ms = (time.monotonic() - t_start) * 1000
         fetched = [t for t in requested if t not in failed]

--- a/mcp/src/threat_intel_mcp/normalize.py
+++ b/mcp/src/threat_intel_mcp/normalize.py
@@ -89,11 +89,11 @@ def deduplicate_iocs(iocs: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def finalize_iocs(iocs: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Validate, sanitise, then deduplicate — the standard adapter output pipeline.
+    """Sanitise, validate, then deduplicate — the standard adapter output pipeline.
 
-    Order matters: schema validation first (drop malformed objects), then
-    sanitisation of feed-controlled free-text (strip control/zero-width chars,
-    cap lengths, drop emptied values), then dedup on the cleaned values so that
+    Order matters: sanitisation first (strip control/zero-width chars, drop
+    emptied or over-length values), so that schema validation always runs on
+    the *cleaned* values, then dedup on those cleaned values so that
     hidden-character variants of the same indicator collapse together.
     """
-    return deduplicate_iocs(sanitize_iocs(validate_iocs(iocs)))
+    return deduplicate_iocs(validate_iocs(sanitize_iocs(iocs)))

--- a/mcp/src/threat_intel_mcp/sanitize.py
+++ b/mcp/src/threat_intel_mcp/sanitize.py
@@ -14,7 +14,10 @@ bounds field length. Enum-constrained fields (``type``, ``confidence``, ``tlp``,
 ``action``) are left untouched because the schema already restricts them.
 
 An IOC whose ``value`` is emptied by cleaning (it was pure control/zero-width
-junk) is dropped — a malformed indicator is worse than a missing one.
+junk) or exceeds the length bound is **dropped**, never truncated — a truncated
+indicator is a *different*, plausible-looking indicator, which is fabrication
+(R3). Truncation is applied only to annotation fields (tags, threat/actor
+names), where clipping loses detail but cannot mint a false indicator.
 """
 
 from __future__ import annotations
@@ -43,11 +46,16 @@ _MAX_TAGS = 32
 _FREE_TEXT_FIELDS = ("associated_threat", "associated_actor", "kill_chain_phase")
 
 
-def _clean_str(value: str, max_len: int) -> str:
-    """Strip control + zero-width/bidi chars, trim, and cap length."""
+def _strip_chars(value: str) -> str:
+    """Strip control + zero-width/bidi chars and trim whitespace."""
     cleaned = _ZERO_WIDTH_RE.sub("", value)
     cleaned = _CONTROL_RE.sub("", cleaned)
-    cleaned = cleaned.strip()
+    return cleaned.strip()
+
+
+def _clean_str(value: str, max_len: int) -> str:
+    """Strip disallowed chars and cap length (annotation fields only)."""
+    cleaned = _strip_chars(value)
     if len(cleaned) > max_len:
         cleaned = cleaned[:max_len]
     return cleaned
@@ -59,9 +67,16 @@ def sanitize_ioc(ioc: dict[str, Any]) -> dict[str, Any] | None:
 
     raw_value = out.get("value")
     if isinstance(raw_value, str):
-        cleaned_value = _clean_str(raw_value, _MAX_VALUE_LEN)
+        cleaned_value = _strip_chars(raw_value)
         if not cleaned_value:
             logger.warning("Dropping IOC whose value sanitised to empty.")
+            return None
+        if len(cleaned_value) > _MAX_VALUE_LEN:
+            # Never truncate an indicator value: a clipped URL/domain is a
+            # different, plausible-but-wrong IOC — that's fabrication (R3).
+            logger.warning(
+                "Dropping IOC whose value exceeds %d chars.", _MAX_VALUE_LEN
+            )
             return None
         out["value"] = cleaned_value
 

--- a/mcp/src/threat_intel_mcp/server.py
+++ b/mcp/src/threat_intel_mcp/server.py
@@ -63,7 +63,31 @@ _otx = OTXAdapter(_credentials)
 # Fan-out registry: each source carries its own circuit breaker so one flaky
 # feed cannot take down a fetch_all_iocs call. Credential/config errors are
 # treated as non-retryable and surface as "unverified" in the Coverage Ledger.
-_CONFIG_ERRORS: tuple[type[BaseException], ...] = (CredentialError, KeyError)
+# ValueError covers caller mistakes (bad time_range / feed_types) — not an
+# upstream-health signal, so it must not trip a breaker or be retried.
+_CONFIG_ERRORS: tuple[type[BaseException], ...] = (CredentialError, KeyError, ValueError)
+
+
+def _degraded_tool_result(
+    source: str, tier: int, partial: list[str], error: str
+) -> dict[str, Any]:
+    """Uniform degraded response for a single-feed tool that could not fetch."""
+    return {
+        "iocs": [],
+        "source": source,
+        "tier": tier,
+        "retrieved_at": "",
+        "record_count": 0,
+        "latency_ms": 0.0,
+        "feed_types_fetched": [],
+        "partial_failure": partial,
+        "coverage_ledger_entry": {
+            "tier": tier,
+            "source": source,
+            "status": "unverified",
+        },
+        "error": error,
+    }
 _FEED_SOURCES = [
     FeedSource(_qfeeds, 2, "Q-Feeds", CircuitBreaker("Q-Feeds"), _CONFIG_ERRORS),
     FeedSource(_abuseipdb, 3, "AbuseIPDB", CircuitBreaker("AbuseIPDB"), _CONFIG_ERRORS),
@@ -100,7 +124,26 @@ async def qfeeds_fetch_iocs(
         3. Set skill_input.feed_integrations = [{"name": "Q-Feeds", "tier": 2,
            "access_level": "premium"}] so the Coverage Ledger marks it consulted.
     """
-    result = await _qfeeds.fetch(time_range=time_range, feed_types=feed_types)
+    try:
+        result = await _qfeeds.fetch(time_range=time_range, feed_types=feed_types)
+    except (CredentialError, KeyError) as exc:
+        logger.warning("Q-Feeds credential error: %s", type(exc).__name__)
+        return _degraded_tool_result(
+            "Q-Feeds",
+            2,
+            feed_types or list(QFEEDS_FEED_TYPES.keys()),
+            "Q-Feeds credential not configured. Set QFEEDS_API_KEY.",
+        )
+    except ValueError:
+        raise  # invalid feed_types — a caller error worth surfacing verbatim
+    except Exception as exc:
+        logger.warning("Q-Feeds upstream fetch failed: %s", type(exc).__name__)
+        return _degraded_tool_result(
+            "Q-Feeds",
+            2,
+            feed_types or list(QFEEDS_FEED_TYPES.keys()),
+            f"upstream fetch failed: {type(exc).__name__}",
+        )
 
     deduped = finalize_iocs(result.iocs)
 
@@ -156,23 +199,18 @@ async def abuseipdb_fetch_blocklist(
     try:
         result = await _abuseipdb.fetch(time_range=time_range, feed_types=feed_types)
     except (CredentialError, KeyError) as exc:
-        logger.warning("AbuseIPDB credential error: %s", exc)
-        return {
-            "iocs": [],
-            "source": "AbuseIPDB",
-            "tier": 3,
-            "retrieved_at": "",
-            "record_count": 0,
-            "latency_ms": 0.0,
-            "feed_types_fetched": [],
-            "partial_failure": ["blacklist"],
-            "coverage_ledger_entry": {
-                "tier": 3,
-                "source": "AbuseIPDB",
-                "status": "unverified",
-            },
-            "error": "AbuseIPDB credential not configured. Set ABUSEIPDB_API_KEY.",
-        }
+        logger.warning("AbuseIPDB credential error: %s", type(exc).__name__)
+        return _degraded_tool_result(
+            "AbuseIPDB",
+            3,
+            ["blacklist"],
+            "AbuseIPDB credential not configured. Set ABUSEIPDB_API_KEY.",
+        )
+    except Exception as exc:
+        logger.warning("AbuseIPDB upstream fetch failed: %s", type(exc).__name__)
+        return _degraded_tool_result(
+            "AbuseIPDB", 3, ["blacklist"], f"upstream fetch failed: {type(exc).__name__}"
+        )
 
     deduped = finalize_iocs(result.iocs)
 
@@ -228,22 +266,22 @@ async def virustotal_fetch_iocs(
         result = await _virustotal.fetch(time_range=time_range, feed_types=feed_types)
     except (CredentialError, KeyError) as exc:
         logger.warning("VirusTotal credential error: %s", type(exc).__name__)
-        return {
-            "iocs": [],
-            "source": "VirusTotal",
-            "tier": 2,
-            "retrieved_at": "",
-            "record_count": 0,
-            "latency_ms": 0.0,
-            "feed_types_fetched": [],
-            "partial_failure": feed_types or list(VT_FEED_TYPES.keys()),
-            "coverage_ledger_entry": {
-                "tier": 2,
-                "source": "VirusTotal",
-                "status": "unverified",
-            },
-            "error": "VT_API_KEY credential not configured",
-        }
+        return _degraded_tool_result(
+            "VirusTotal",
+            2,
+            feed_types or list(VT_FEED_TYPES.keys()),
+            "VT_API_KEY credential not configured",
+        )
+    except ValueError:
+        raise  # invalid feed_types — a caller error worth surfacing verbatim
+    except Exception as exc:
+        logger.warning("VirusTotal upstream fetch failed: %s", type(exc).__name__)
+        return _degraded_tool_result(
+            "VirusTotal",
+            2,
+            feed_types or list(VT_FEED_TYPES.keys()),
+            f"upstream fetch failed: {type(exc).__name__}",
+        )
 
     deduped = finalize_iocs(result.iocs)
 
@@ -298,23 +336,23 @@ async def otx_fetch_iocs(
     try:
         result = await _otx.fetch(time_range=time_range, feed_types=feed_types)
     except (CredentialError, KeyError) as exc:
-        logger.warning("OTX credential error: %s", exc)
-        return {
-            "iocs": [],
-            "source": "AlienVault OTX",
-            "tier": 2,
-            "retrieved_at": "",
-            "record_count": 0,
-            "latency_ms": 0.0,
-            "feed_types_fetched": [],
-            "partial_failure": ["subscribed"],
-            "coverage_ledger_entry": {
-                "tier": 2,
-                "source": "AlienVault OTX",
-                "status": "unverified",
-            },
-            "error": "OTX credentials not configured. Set OTX_API_KEY environment variable.",
-        }
+        logger.warning("OTX credential error: %s", type(exc).__name__)
+        return _degraded_tool_result(
+            "AlienVault OTX",
+            2,
+            ["subscribed"],
+            "OTX credentials not configured. Set OTX_API_KEY environment variable.",
+        )
+    except ValueError:
+        raise  # invalid time_range — a caller error worth surfacing verbatim
+    except Exception as exc:
+        logger.warning("OTX upstream fetch failed: %s", type(exc).__name__)
+        return _degraded_tool_result(
+            "AlienVault OTX",
+            2,
+            ["subscribed"],
+            f"upstream fetch failed: {type(exc).__name__}",
+        )
 
     deduped = finalize_iocs(result.iocs)
 

--- a/mcp/tests/test_normalize.py
+++ b/mcp/tests/test_normalize.py
@@ -1,6 +1,6 @@
 """Tests for the normaliser: schema validation and deduplication."""
 
-from threat_intel_mcp.normalize import deduplicate_iocs, validate_iocs
+from threat_intel_mcp.normalize import deduplicate_iocs, finalize_iocs, validate_iocs
 
 
 def _ioc(type_: str, value: str, confidence: str = "High", source: str = "Q-Feeds") -> dict:
@@ -82,3 +82,35 @@ class TestDeduplicateIocs:
         iocs = [_ioc("IPv4", "1.1.1.1"), _ioc("Domain", "1.1.1.1")]
         result = deduplicate_iocs(iocs)
         assert len(result) == 2
+
+
+class TestFinalizeIocs:
+    """finalize_iocs = sanitize -> validate -> dedupe (issue #57 ordering)."""
+
+    def test_sanitizes_before_validating(self):
+        # Dirty-but-salvageable value is cleaned, then validated, then kept.
+        iocs = [
+            {"type": "IPv4", "value": "1.2.3.4\x00", "confidence": "High", "source": "F"},
+        ]
+        out = finalize_iocs(iocs)
+        assert [i["value"] for i in out] == ["1.2.3.4"]
+
+    def test_drops_over_length_and_emptied_values(self):
+        long_url = "https://evil.example/" + "a" * 3000
+        iocs = [
+            {"type": "URL", "value": long_url, "confidence": "High", "source": "F"},
+            {"type": "IPv4", "value": "\x00\x07", "confidence": "High", "source": "F"},
+            {"type": "IPv4", "value": "5.5.5.5", "confidence": "High", "source": "F"},
+        ]
+        out = finalize_iocs(iocs)
+        assert [i["value"] for i in out] == ["5.5.5.5"]
+
+    def test_dedupes_on_cleaned_values(self):
+        # Hidden-character variant of the same indicator collapses after cleaning.
+        iocs = [
+            {"type": "IPv4", "value": "1.2.3.4", "confidence": "Low", "source": "A"},
+            {"type": "IPv4", "value": "1.2\u200b.3.4", "confidence": "High", "source": "B"},
+        ]
+        out = finalize_iocs(iocs)
+        assert len(out) == 1
+        assert out[0]["confidence"] == "High"

--- a/mcp/tests/test_otx.py
+++ b/mcp/tests/test_otx.py
@@ -291,14 +291,15 @@ class TestOTXAdapterFetch:
         assert result.partial_failure == []
 
     @pytest.mark.asyncio
-    async def test_http_error_recorded_as_partial_failure(self, adapter, httpx_mock: HTTPXMock):
+    async def test_http_error_raises(self, adapter, httpx_mock: HTTPXMock):
+        # OTX has a single feed, so an upstream failure is total: it must
+        # propagate so the fan-out's retry/circuit-breaker layer sees it.
         httpx_mock.add_callback(
             lambda req: _make_error_response(401),
             url=_OTX_SUBSCRIBED_RE,
         )
-        result = await adapter.fetch(time_range="7d")
-        assert "subscribed" in result.partial_failure
-        assert result.record_count == 0
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.fetch(time_range="7d")
 
     @pytest.mark.asyncio
     async def test_otx_tag_present_on_all_iocs(self, adapter, httpx_mock: HTTPXMock):

--- a/mcp/tests/test_qfeeds.py
+++ b/mcp/tests/test_qfeeds.py
@@ -5,6 +5,7 @@ Each test provides a mock response matching what Q-Feeds returns for that
 feed type; the adapter's normaliser must produce valid ioc_network objects.
 """
 
+import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -157,6 +158,16 @@ class TestQFeedsAdapterFetch:
         result = await adapter.fetch()
         assert "malware_domains" in result.partial_failure
         assert result.record_count > 0  # IP feed still returned
+
+    @pytest.mark.asyncio
+    async def test_total_failure_raises(self, adapter, httpx_mock: HTTPXMock):
+        # Every requested feed type fails -> the adapter must propagate so the
+        # fan-out's retry/circuit-breaker layer can act on it (issue #56).
+        httpx_mock.add_response(url=_API_URL, match_params=_ip_params(), status_code=500)
+        httpx_mock.add_response(url=_API_URL, match_params=_domain_params(), status_code=503)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.fetch()
 
     @pytest.mark.asyncio
     async def test_cache_avoids_second_request(self, adapter, httpx_mock: HTTPXMock):

--- a/mcp/tests/test_sanitize.py
+++ b/mcp/tests/test_sanitize.py
@@ -46,6 +46,17 @@ class TestSanitizeIoc:
         out = sanitize_ioc(_ioc(associated_threat="x" * 5000))
         assert len(out["associated_threat"]) == 512
 
+    def test_over_length_value_dropped_not_truncated(self):
+        # Truncating an indicator value fabricates a different, plausible-but-
+        # wrong IOC (R3) — over-length values must drop the whole IOC.
+        long_url = "https://evil.example/" + "a" * 3000
+        assert sanitize_ioc(_ioc(type="URL", value=long_url)) is None
+
+    def test_value_at_length_limit_kept(self):
+        exact = "a" * 2048
+        out = sanitize_ioc(_ioc(value=exact))
+        assert out["value"] == exact
+
     def test_tags_cleaned_filtered_and_capped(self):
         # "ev‍il" has a zero-width joiner (200d) inside → cleans to "evil".
         out = sanitize_ioc(

--- a/mcp/tests/test_virustotal.py
+++ b/mcp/tests/test_virustotal.py
@@ -7,6 +7,7 @@ feed type; the adapter's normaliser must produce valid ioc_network objects.
 
 from __future__ import annotations
 
+import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -226,6 +227,20 @@ class TestVirusTotalAdapterFetch:
         result = await adapter.fetch(feed_types=["malicious_ips", "malicious_domains"])
         assert "malicious_domains" in result.partial_failure
         assert result.record_count > 0  # IP feed still returned data
+
+    @pytest.mark.asyncio
+    async def test_total_failure_raises(self, adapter, httpx_mock: HTTPXMock):
+        # Every requested feed type fails -> the adapter must propagate so the
+        # fan-out's retry/circuit-breaker layer can act on it (issue #56).
+        httpx_mock.add_response(
+            url=_IP_FEED_URL, match_params=_IP_PARAMS, status_code=500
+        )
+        httpx_mock.add_response(
+            url=_DOMAIN_FEED_URL, match_params=_DOMAIN_PARAMS, status_code=503
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.fetch(feed_types=["malicious_ips", "malicious_domains"])
 
     @pytest.mark.asyncio
     async def test_domain_feed_returns_domain_type(self, adapter, httpx_mock: HTTPXMock):


### PR DESCRIPTION
## Summary

Fixes the three **High**-severity findings from the 2026-06-29 full-repo review. Closes #55, closes #56, closes #57.

### Vault docs pointed at the wrong KV path (#55)
All four `vault kv put` examples and the rotation-playbook command now use the path convention the provider actually reads: `vault kv put secret/<adapter>/api_key api_key=<key>` (KV v2 data path `secret/data/<adapter>/api_key`, field `api_key`). The old commands wrote to `secret/<adapter>` — a path the code never reads, so following the docs produced `CredentialError` at runtime. Added an explanatory note so the convention is visible next to the commands.

### Retry/circuit-breaker now actually engage (#56)
- **Q-Feeds / VirusTotal / OTX adapters propagate total failure** (every requested feed type failed) instead of swallowing it into `partial_failure` — so `guarded_fetch`'s bounded retry and per-source circuit breaker finally see the common "feed down" case. Genuinely partial results (some feed types succeeded) still return as partial, which should *not* be retried away.
- Audit log records `status="error"` on the raise path, preserving the invocation trail.
- **All four single-feed MCP tools** now share a `_degraded_tool_result` helper: credential errors *and* upstream failures return the graceful degraded dict. This also fixes the adjacent gap where `qfeeds_fetch_iocs` had **no** error handling at all (missing `QFEEDS_API_KEY` errored the tool call).
- `ValueError` (bad `time_range`/`feed_types` — caller error, not upstream health) re-raises verbatim from tools and joins the fan-out's non-retryable config errors so it can't trip a breaker.

### Sanitizer no longer fabricates by truncation (#57)
- Over-length IOC **values are dropped, never truncated** — a clipped URL/domain is a different, plausible-but-wrong indicator (R3). Truncation remains for annotation fields (`tags`, threat/actor names) where clipping can't mint a false indicator.
- `finalize_iocs` reordered to **sanitize → validate → dedupe**, so schema validation always runs on cleaned values and hidden-character variants dedupe correctly.

## Test plan

- [x] `cd mcp && python -m pytest tests/ -q` — **176 passed** (169 prior + 7 new)
- [x] `ruff check src/ tests/` — clean
- [x] OTX swallow-test rewritten to expect `httpx.HTTPStatusError`; new total-failure raise tests for Q-Feeds and VT; partial-failure tests unchanged and passing (one feed succeeding still returns partial)
- [x] Sanitize: over-length value dropped, exactly-at-limit value kept, free-text truncation unchanged
- [x] New `finalize_iocs` tests: cleans before validating, drops over-length/emptied values, dedupes hidden-character variants to highest confidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ)_