### PR TITLE
Fix Medium/Low review findings: credential semantics, breaker contract, data quality (v0.8.0)

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "threat-intel-mcp"
-version = "0.7.0"
+version = "0.8.0"
 description = "MCP server that delivers live threat intelligence feeds to Claude, normalised to the threat-intel skill schema"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -13,6 +13,7 @@ dependencies = [
     "mcp>=1.0",
     "httpx>=0.27",
     "jsonschema>=4.23",
+    "rfc3339-validator>=0.1",
     "anyio>=4.4",
     "hvac>=2.0",
 ]

--- a/mcp/src/threat_intel_mcp/adapters/abuseipdb.py
+++ b/mcp/src/threat_intel_mcp/adapters/abuseipdb.py
@@ -88,7 +88,7 @@ class AbuseIPDBAdapter:
             headers={
                 "Key": api_key,
                 "Accept": "application/json",
-                "User-Agent": "threat-intel-mcp/0.1 (kj299/threat-intel)",
+                "User-Agent": "threat-intel-mcp/0.8 (kj299/threat-intel)",
             },
             timeout=httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=5.0),
             event_hooks=egress_event_hooks("api.abuseipdb.com"),

--- a/mcp/src/threat_intel_mcp/adapters/otx.py
+++ b/mcp/src/threat_intel_mcp/adapters/otx.py
@@ -144,7 +144,7 @@ class OTXAdapter:
         return httpx.AsyncClient(
             headers={
                 "X-OTX-API-KEY": api_key,
-                "User-Agent": "threat-intel-mcp/0.3 (kj299/threat-intel)",
+                "User-Agent": "threat-intel-mcp/0.8 (kj299/threat-intel)",
             },
             timeout=httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=5.0),
             event_hooks=egress_event_hooks("otx.alienvault.com"),

--- a/mcp/src/threat_intel_mcp/adapters/qfeeds.py
+++ b/mcp/src/threat_intel_mcp/adapters/qfeeds.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import logging
-import re
 import time
 from datetime import datetime, timezone
 from typing import Any
@@ -51,9 +50,6 @@ CACHE_TTL_SECONDS = 1200
 # Q-Feeds paginates at 4,000 records per page.
 PAGE_SIZE = 4000
 
-_IPV4_RE = re.compile(r"^\d{1,3}(?:\.\d{1,3}){3}$")
-_IPV6_RE = re.compile(r"^[0-9a-fA-F:]+$")
-
 
 class QFeedsAdapter:
     """Adapter for Q-Feeds (qfeeds.com) threat intelligence feeds."""
@@ -72,7 +68,7 @@ class QFeedsAdapter:
         return httpx.AsyncClient(
             auth=("api_token", api_key),
             timeout=httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=5.0),
-            headers={"User-Agent": "threat-intel-mcp/0.1 (kj299/threat-intel)"},
+            headers={"User-Agent": "threat-intel-mcp/0.8 (kj299/threat-intel)"},
             event_hooks=egress_event_hooks("api.qfeeds.com"),
         )
 
@@ -220,13 +216,15 @@ def _normalize_line(line: str, feed_type: str) -> dict[str, Any] | None:
                 logger.debug("Invalid CIDR, skipping: %r", line)
                 return None
             ioc_type = "CIDR_Range"
-        elif ":" in line:
-            ioc_type = "IPv6"
-        elif _IPV4_RE.match(line):
-            ioc_type = "IPv4"
         else:
-            logger.debug("Unrecognised IP-feed line, skipping: %r", line)
-            return None
+            # Real address parsing — rejects out-of-range octets (999.1.1.1)
+            # and colon-containing junk a regex would misclassify as IPv6.
+            try:
+                addr = ipaddress.ip_address(line)
+            except ValueError:
+                logger.debug("Unrecognised IP-feed line, skipping: %r", line)
+                return None
+            ioc_type = "IPv4" if addr.version == 4 else "IPv6"
 
     elif feed_type == "malware_domains":
         if line.startswith(("http://", "https://")):

--- a/mcp/src/threat_intel_mcp/adapters/virustotal.py
+++ b/mcp/src/threat_intel_mcp/adapters/virustotal.py
@@ -138,7 +138,7 @@ class VirusTotalAdapter:
         return httpx.AsyncClient(
             headers={
                 "x-apikey": api_key,
-                "User-Agent": "threat-intel-mcp/0.3 (kj299/threat-intel)",
+                "User-Agent": "threat-intel-mcp/0.8 (kj299/threat-intel)",
                 "Accept": "application/json",
             },
             timeout=httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=5.0),

--- a/mcp/src/threat_intel_mcp/normalize.py
+++ b/mcp/src/threat_intel_mcp/normalize.py
@@ -49,7 +49,11 @@ _IOC_NETWORK_SCHEMA: dict[str, Any] = {
     },
 }
 
-_validator = jsonschema.Draft7Validator(_IOC_NETWORK_SCHEMA)
+# FormatChecker enforces "format": "date-time" on first_seen/last_seen at
+# runtime (requires the rfc3339-validator package, declared in pyproject).
+_validator = jsonschema.Draft7Validator(
+    _IOC_NETWORK_SCHEMA, format_checker=jsonschema.FormatChecker()
+)
 
 
 def validate_iocs(iocs: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -72,19 +76,52 @@ def validate_iocs(iocs: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return valid
 
 
+_CONF_RANK = {"High": 3, "Medium": 2, "Low": 1}
+
+
+def _merge_duplicate(kept: dict[str, Any], other: dict[str, Any]) -> dict[str, Any]:
+    """Fold a duplicate IOC into the kept copy without losing corroboration.
+
+    Returns a NEW dict — the inputs are often references into adapters'
+    in-process caches, so in-place mutation would corrupt cached results.
+    Tags are unioned, and an independent second source is recorded as a
+    ``corroborated-by:<source>`` tag (two feeds reporting the same indicator
+    is signal, not noise).
+    """
+    merged = {**kept}
+    tags = list(merged.get("tags", []))
+    for tag in other.get("tags", []):
+        if tag not in tags:
+            tags.append(tag)
+    other_source = other.get("source")
+    if other_source and other_source != merged.get("source"):
+        corroboration = f"corroborated-by:{other_source}"
+        if corroboration not in tags:
+            tags.append(corroboration)
+    if tags:
+        merged["tags"] = tags
+    return merged
+
+
 def deduplicate_iocs(iocs: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Deduplicate by (type, value), keeping the highest-confidence copy."""
-    _conf_rank = {"High": 3, "Medium": 2, "Low": 1}
+    """Deduplicate by (type, value), keeping the highest-confidence copy.
+
+    Duplicates are merged, not discarded: tags are unioned and cross-source
+    duplicates gain a ``corroborated-by:<source>`` tag on the kept copy.
+    """
     seen: dict[tuple[str, str], dict[str, Any]] = {}
     for ioc in iocs:
         key = (ioc["type"], ioc["value"])
         if key not in seen:
             seen[key] = ioc
+            continue
+        existing = seen[key]
+        existing_rank = _CONF_RANK.get(existing.get("confidence", "Low"), 1)
+        new_rank = _CONF_RANK.get(ioc.get("confidence", "Low"), 1)
+        if new_rank > existing_rank:
+            seen[key] = _merge_duplicate(ioc, existing)
         else:
-            existing_rank = _conf_rank.get(seen[key].get("confidence", "Low"), 1)
-            new_rank = _conf_rank.get(ioc.get("confidence", "Low"), 1)
-            if new_rank > existing_rank:
-                seen[key] = ioc
+            seen[key] = _merge_duplicate(existing, ioc)
     return list(seen.values())
 
 

--- a/mcp/src/threat_intel_mcp/resilience.py
+++ b/mcp/src/threat_intel_mcp/resilience.py
@@ -54,6 +54,7 @@ class CircuitBreaker:
     _consecutive_failures: int = field(default=0, init=False)
     _opened_at: float | None = field(default=None, init=False)
     _half_open: bool = field(default=False, init=False)
+    _trial_pending: bool = field(default=False, init=False)
 
     @property
     def state(self) -> str:
@@ -72,12 +73,22 @@ class CircuitBreaker:
             logger.info("circuit %s -> half_open", self.name)
 
     def allow(self) -> bool:
-        """Return True if a call may proceed right now."""
+        """Return True if a call may proceed right now.
+
+        In half-open state exactly one trial call is admitted; further callers
+        are rejected until the trial's outcome is recorded via
+        :meth:`record_success` / :meth:`record_failure`.
+        """
         self._maybe_half_open()
         if self._opened_at is None:
             return True
-        # Open: only the single half-open trial call is allowed through.
-        return self._half_open
+        if not self._half_open:
+            return False
+        # Half-open: admit a single trial call.
+        if self._trial_pending:
+            return False
+        self._trial_pending = True
+        return True
 
     def record_success(self) -> None:
         if self._opened_at is not None or self._consecutive_failures:
@@ -85,9 +96,11 @@ class CircuitBreaker:
         self._consecutive_failures = 0
         self._opened_at = None
         self._half_open = False
+        self._trial_pending = False
 
     def record_failure(self) -> None:
         self._consecutive_failures += 1
+        self._trial_pending = False
         if self._half_open:
             # The half-open trial failed: re-open and restart the cooldown.
             self._opened_at = self.clock()

--- a/mcp/src/threat_intel_mcp/server.py
+++ b/mcp/src/threat_intel_mcp/server.py
@@ -88,6 +88,8 @@ def _degraded_tool_result(
         },
         "error": error,
     }
+
+
 _FEED_SOURCES = [
     FeedSource(_qfeeds, 2, "Q-Feeds", CircuitBreaker("Q-Feeds"), _CONFIG_ERRORS),
     FeedSource(_abuseipdb, 3, "AbuseIPDB", CircuitBreaker("AbuseIPDB"), _CONFIG_ERRORS),
@@ -501,7 +503,7 @@ async def list_available_feeds() -> dict[str, Any]:
             "circuit breakers and merged deduplication; degraded feeds surface as "
             "'unverified' in the returned coverage_ledger."
         ),
-        "phase": "3 (Q-Feeds + AbuseIPDB + VirusTotal + AlienVault OTX + concurrent fan-out + HashiCorp Vault or env-var credentials)",
+        "phase": "4 (Q-Feeds + AbuseIPDB + VirusTotal + AlienVault OTX + concurrent fan-out + hardening + HashiCorp Vault or env-var credentials)",
         "planned": ["Shodan", "Recorded Future"],
     }
 

--- a/mcp/src/threat_intel_mcp/transports/base.py
+++ b/mcp/src/threat_intel_mcp/transports/base.py
@@ -48,13 +48,20 @@ class ProtocolAdapter(ABC):
 
     @abstractmethod
     async def _collect(
-        self, *, time_range: str, feed_types: list[str] | None
+        self,
+        *,
+        time_range: str,
+        feed_types: list[str] | None,
+        partial_failure: list[str],
     ) -> list[Any]:
         """Pull raw records from the upstream transport. Implemented per feed.
 
         Should return a list of raw, un-normalised records (dicts, protobuf
-        messages, decoded frames — whatever the transport yields). Network and
-        auth errors should propagate; the fan-out's circuit breaker handles them.
+        messages, decoded frames — whatever the transport yields). A *total*
+        failure should propagate (the fan-out's retry/circuit breaker handles
+        it); a *partial* one (some sub-feeds/topics failed but records were
+        retrieved) should append the failed sub-feed names to
+        ``partial_failure`` and return what succeeded.
         """
 
     @abstractmethod
@@ -71,7 +78,12 @@ class ProtocolAdapter(ABC):
     ) -> FetchResult:
         """Collect, normalise, validate, and deduplicate into a ``FetchResult``."""
         t0 = time.monotonic()
-        raw_records = await self._collect(time_range=time_range, feed_types=feed_types)
+        partial_failure: list[str] = []
+        raw_records = await self._collect(
+            time_range=time_range,
+            feed_types=feed_types,
+            partial_failure=partial_failure,
+        )
         normalized = [
             ioc
             for raw in raw_records
@@ -80,6 +92,7 @@ class ProtocolAdapter(ABC):
         deduped = finalize_iocs(normalized)
         latency_ms = round((time.monotonic() - t0) * 1000, 1)
 
+        requested = feed_types or ([self.protocol] if self.protocol else [])
         return FetchResult(
             iocs=deduped,
             source=self.name,
@@ -87,6 +100,6 @@ class ProtocolAdapter(ABC):
             retrieved_at=datetime.now(timezone.utc).isoformat(),
             record_count=len(deduped),
             latency_ms=latency_ms,
-            feed_types_fetched=feed_types or ([self.protocol] if self.protocol else []),
-            partial_failure=[],
+            feed_types_fetched=[t for t in requested if t not in partial_failure],
+            partial_failure=partial_failure,
         )

--- a/mcp/src/threat_intel_mcp/vault/base.py
+++ b/mcp/src/threat_intel_mcp/vault/base.py
@@ -10,18 +10,33 @@ class CredentialError(Exception):
     """
 
 
+class CredentialNotFoundError(CredentialError, KeyError):
+    """The credential is definitively absent (unset env var, missing Vault path).
+
+    Distinct from a provider *failure* (Vault outage, auth error), which raises
+    plain :class:`CredentialError`: optional-field lookups may default on
+    not-found but must propagate a failure — otherwise a transient outage
+    silently downgrades a feed to unauthenticated/default settings.
+
+    Subclasses ``KeyError`` too so existing ``except (CredentialError, KeyError)``
+    sites keep working unchanged.
+    """
+
+    def __str__(self) -> str:  # KeyError.__str__ repr()s the message; undo that.
+        return Exception.__str__(self)
+
+
 @runtime_checkable
 class CredentialProvider(Protocol):
     """Retrieves secrets for a named adapter and key.
 
     Implementations must never log, print, or otherwise expose the returned value.
-    Phase 2 adds HashicorpVaultProvider; Phase 3 will add AwsSecretsManagerProvider.
     """
 
     def get(self, adapter_name: str, key: str) -> str:
         """Return the secret value for (adapter_name, key).
 
-        Raises CredentialError if authentication fails or the secret is missing.
-        Raises KeyError if not found (legacy; prefer CredentialError in new impls).
+        Raises CredentialNotFoundError if the secret is definitively absent.
+        Raises CredentialError for provider failures (auth, connectivity).
         """
         ...

--- a/mcp/src/threat_intel_mcp/vault/env.py
+++ b/mcp/src/threat_intel_mcp/vault/env.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+from .base import CredentialNotFoundError
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,7 +28,7 @@ class EnvCredentialProvider:
         env_var = f"{adapter_name.upper()}_{key.upper()}"
         value = os.environ.get(env_var)
         if value is None:
-            raise KeyError(
+            raise CredentialNotFoundError(
                 f"Credential not found. Expected environment variable {env_var!r} "
                 f"to be set. Set it with: export {env_var}=<your-key>"
             )

--- a/mcp/src/threat_intel_mcp/vault/hashicorp.py
+++ b/mcp/src/threat_intel_mcp/vault/hashicorp.py
@@ -7,7 +7,7 @@ import logging
 import hvac
 import hvac.exceptions
 
-from .base import CredentialError
+from .base import CredentialError, CredentialNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ class VaultCredentialProvider:
             # Let Forbidden propagate so get() can attempt token renewal.
             raise
         except hvac.exceptions.InvalidPath:
-            raise CredentialError(
+            raise CredentialNotFoundError(
                 f"Secret not found at path '{self._mount_point}/data/{path}'. "
                 "Ensure the secret exists in Vault."
             )
@@ -90,7 +90,7 @@ class VaultCredentialProvider:
         try:
             value = response["data"]["data"][key]
         except (KeyError, TypeError):
-            raise CredentialError(
+            raise CredentialNotFoundError(
                 f"Key '{key}' not present in Vault secret at "
                 f"'{self._mount_point}/data/{path}'."
             )

--- a/mcp/src/threat_intel_mcp/vault/protocols.py
+++ b/mcp/src/threat_intel_mcp/vault/protocols.py
@@ -22,17 +22,22 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .base import CredentialError, CredentialProvider
+from .base import CredentialError, CredentialNotFoundError, CredentialProvider
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
 
 def _require(provider: CredentialProvider, adapter: str, key: str) -> str:
-    """Fetch a mandatory credential field, normalising the not-found error."""
+    """Fetch a mandatory credential field, normalising the not-found error.
+
+    A definitive not-found gets the friendly "store it here" message; a provider
+    failure (Vault outage, auth error) propagates untouched — it is not a
+    configuration problem and must not be reported as one.
+    """
     try:
         value = provider.get(adapter, key)
-    except (CredentialError, KeyError):
-        raise CredentialError(
+    except (CredentialNotFoundError, KeyError):
+        raise CredentialNotFoundError(
             f"Missing required credential '{key}' for protocol feed '{adapter}'. "
             f"Store it as env {adapter.upper()}_{key.upper()} or Vault "
             f"{adapter}/{key}."
@@ -47,10 +52,15 @@ def _require(provider: CredentialProvider, adapter: str, key: str) -> str:
 def _optional(
     provider: CredentialProvider, adapter: str, key: str, default: str | None = None
 ) -> str | None:
-    """Fetch an optional credential field, returning ``default`` if absent/empty."""
+    """Fetch an optional credential field, returning ``default`` only if absent.
+
+    Only a definitive not-found falls back to the default. A provider *failure*
+    propagates: silently defaulting on a Vault outage would downgrade a feed to
+    unauthenticated/default settings (issue #58).
+    """
     try:
         value = provider.get(adapter, key)
-    except (CredentialError, KeyError):
+    except (CredentialNotFoundError, KeyError):
         return default
     return value or default
 

--- a/mcp/tests/test_normalize.py
+++ b/mcp/tests/test_normalize.py
@@ -114,3 +114,61 @@ class TestFinalizeIocs:
         out = finalize_iocs(iocs)
         assert len(out) == 1
         assert out[0]["confidence"] == "High"
+
+
+class TestCorroborationDedupe:
+    """Cross-source duplicates preserve corroboration (issue #61)."""
+
+    def _ioc(self, source, confidence="High", tags=None):
+        out = {"type": "IPv4", "value": "1.2.3.4", "confidence": confidence, "source": source}
+        if tags is not None:
+            out["tags"] = tags
+        return out
+
+    def test_cross_source_duplicate_gains_corroboration_tag(self):
+        out = deduplicate_iocs([self._ioc("A", "High"), self._ioc("B", "Low")])
+        assert len(out) == 1
+        assert out[0]["source"] == "A"
+        assert "corroborated-by:B" in out[0]["tags"]
+
+    def test_lower_confidence_first_still_corroborates(self):
+        out = deduplicate_iocs([self._ioc("A", "Low"), self._ioc("B", "High")])
+        assert out[0]["source"] == "B"
+        assert "corroborated-by:A" in out[0]["tags"]
+
+    def test_same_source_duplicate_gets_no_corroboration_tag(self):
+        out = deduplicate_iocs([self._ioc("A"), self._ioc("A")])
+        assert "tags" not in out[0] or not any(
+            t.startswith("corroborated-by:") for t in out[0]["tags"]
+        )
+
+    def test_tags_unioned(self):
+        out = deduplicate_iocs(
+            [self._ioc("A", tags=["x"]), self._ioc("B", "Low", tags=["y", "x"])]
+        )
+        assert out[0]["tags"][:2] == ["x", "y"]
+
+    def test_originals_not_mutated(self):
+        a = self._ioc("A", tags=["x"])
+        b = self._ioc("B", "Low")
+        deduplicate_iocs([a, b])
+        assert a["tags"] == ["x"]        # no corroboration tag leaked into input
+        assert "tags" not in b
+
+
+class TestRuntimeFormatChecking:
+    """date-time format enforced at runtime (issue #61)."""
+
+    def test_invalid_first_seen_rejected(self):
+        bad = {
+            "type": "IPv4", "value": "1.2.3.4", "confidence": "High",
+            "source": "F", "first_seen": "not-a-date",
+        }
+        assert validate_iocs([bad]) == []
+
+    def test_valid_first_seen_accepted(self):
+        good = {
+            "type": "IPv4", "value": "1.2.3.4", "confidence": "High",
+            "source": "F", "first_seen": "2026-01-01T00:00:00+00:00",
+        }
+        assert len(validate_iocs([good])) == 1

--- a/mcp/tests/test_protocol_adapter.py
+++ b/mcp/tests/test_protocol_adapter.py
@@ -26,7 +26,7 @@ class FakeGraphQLAdapter(ProtocolAdapter):
         self._records = records
         self.collect_calls = 0
 
-    async def _collect(self, *, time_range, feed_types):
+    async def _collect(self, *, time_range, feed_types, partial_failure):
         self.collect_calls += 1
         return self._records
 
@@ -102,3 +102,17 @@ async def test_drops_into_fanout_unchanged():
     assert result["record_count"] == 1
     assert result["sources_consulted"] == ["FakeGraphQL"]
     assert result["iocs"][0]["value"] == "9.9.9.9"
+
+
+@pytest.mark.asyncio
+async def test_collect_can_report_partial_failure():
+    class PartialAdapter(FakeGraphQLAdapter):
+        async def _collect(self, *, time_range, feed_types, partial_failure):
+            partial_failure.append("topic-b")
+            return self._records
+
+    adapter = PartialAdapter([{"ip": "1.1.1.1", "confidence": "High"}])
+    result = await adapter.fetch(feed_types=["topic-a", "topic-b"])
+    assert result.partial_failure == ["topic-b"]
+    assert result.feed_types_fetched == ["topic-a"]
+    assert result.record_count == 1

--- a/mcp/tests/test_protocol_credentials.py
+++ b/mcp/tests/test_protocol_credentials.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from threat_intel_mcp.vault.base import CredentialError
+from threat_intel_mcp.vault.base import CredentialError, CredentialNotFoundError
 from threat_intel_mcp.vault.protocols import (
     GRPCCredentials,
     GraphQLCredentials,
@@ -28,7 +28,16 @@ class DictCredentials:
         try:
             return self._values[(adapter_name, key)]
         except KeyError:
-            raise CredentialError(f"no such secret {adapter_name}/{key}") from None
+            raise CredentialNotFoundError(
+                f"no such secret {adapter_name}/{key}"
+            ) from None
+
+
+class OutageCredentials:
+    """Provider whose backend is down: every lookup is a failure, not a miss."""
+
+    def get(self, adapter_name: str, key: str) -> str:
+        raise CredentialError("vault sealed / connection refused")
 
 
 # ---------------------------------------------------------------------------
@@ -196,3 +205,30 @@ class TestDispatch:
     def test_unsupported_protocol_raises(self):
         with pytest.raises(CredentialError, match="Unsupported protocol"):
             load_protocol_credentials("smtp", DictCredentials({}), "x")
+
+
+class TestProviderOutage:
+    """A provider failure must propagate — never silently default (issue #58)."""
+
+    def test_outage_propagates_from_optional_field(self):
+        # Required field resolves; the OPTIONAL token lookup hits the outage.
+        # Silently defaulting here would mean unauthenticated feed requests.
+        class MixedOutage:
+            def get(self, adapter_name: str, key: str) -> str:
+                if key == "endpoint":
+                    return "https://e/graphql"
+                raise CredentialError("vault sealed / connection refused")
+
+        with pytest.raises(CredentialError, match="sealed"):
+            GraphQLCredentials.from_provider(MixedOutage(), "g")
+
+    def test_outage_propagates_from_required_field(self):
+        # Must NOT be rewritten into a "missing credential" config message.
+        with pytest.raises(CredentialError, match="sealed"):
+            MQTTCredentials.from_provider(OutageCredentials(), "mq")
+
+    def test_not_found_error_is_both_credential_and_key_error(self):
+        err = CredentialNotFoundError("x")
+        assert isinstance(err, CredentialError)
+        assert isinstance(err, KeyError)
+        assert str(err) == "x"  # KeyError repr-quoting undone

--- a/mcp/tests/test_qfeeds.py
+++ b/mcp/tests/test_qfeeds.py
@@ -184,3 +184,21 @@ class TestQFeedsAdapterFetch:
         result = await adapter.fetch(feed_types=["malware_ip"])
         from datetime import datetime
         datetime.fromisoformat(result.retrieved_at)
+
+
+class TestIpValidation:
+    """Real address parsing (issue #61): no out-of-range octets, no colon junk."""
+
+    def test_out_of_range_octets_skipped(self):
+        assert _normalize_line("999.999.999.999", "malware_ip") is None
+
+    def test_colon_junk_not_classified_as_ipv6(self):
+        assert _normalize_line("foo:bar", "malware_ip") is None
+
+    def test_valid_ipv6_kept(self):
+        out = _normalize_line("2001:db8::1", "malware_ip")
+        assert out is not None and out["type"] == "IPv6"
+
+    def test_valid_ipv4_kept(self):
+        out = _normalize_line("203.0.113.7", "malware_ip")
+        assert out is not None and out["type"] == "IPv4"

--- a/mcp/tests/test_resilience.py
+++ b/mcp/tests/test_resilience.py
@@ -83,6 +83,27 @@ class TestCircuitBreaker:
         assert cb.state == "closed"
         assert cb.allow() is True
 
+    def test_half_open_admits_exactly_one_trial(self):
+        clock = FakeClock()
+        cb = CircuitBreaker("x", failure_threshold=1, reset_timeout=10.0, clock=clock)
+        cb.record_failure()
+        clock.advance(11.0)
+        assert cb.allow() is True   # the single trial
+        assert cb.allow() is False  # concurrent caller rejected
+        assert cb.allow() is False
+        cb.record_success()
+        assert cb.allow() is True   # closed again
+
+    def test_half_open_trial_slot_freed_after_failure(self):
+        clock = FakeClock()
+        cb = CircuitBreaker("x", failure_threshold=1, reset_timeout=10.0, clock=clock)
+        cb.record_failure()
+        clock.advance(11.0)
+        assert cb.allow() is True
+        cb.record_failure()          # trial failed -> open, cooldown restarts
+        clock.advance(11.0)
+        assert cb.allow() is True    # next half-open window admits a new trial
+
     def test_half_open_failure_reopens_and_restarts_cooldown(self):
         clock = FakeClock()
         cb = CircuitBreaker("x", failure_threshold=1, reset_timeout=10.0, clock=clock)


### PR DESCRIPTION
## Summary

Fixes the Medium/Low code findings from the 2026-06-29 full-repo review. Closes #58, closes #61.

### Credential semantics (#58)
- New `CredentialNotFoundError(CredentialError, KeyError)` distinguishes a **definitively absent** secret from a **provider failure**. `EnvCredentialProvider` raises it for unset env vars; `VaultCredentialProvider` for `InvalidPath` / missing-key-in-secret. Dual inheritance keeps every existing `except (CredentialError, KeyError)` site working unchanged.
- `protocols._optional` now defaults **only on not-found** — a Vault outage/auth failure propagates instead of silently downgrading a feed to unauthenticated/default settings. `_require` reports "missing credential" only for genuine not-found; outages surface as-is.

### Circuit-breaker contract (#58)
- Half-open now admits **exactly one trial call**: `allow()` consumes a trial token; concurrent callers are rejected until `record_success`/`record_failure` settles the outcome. Matches the documented single-trial semantics.

### Data quality / design (#61)
- **qfeeds**: IP lines parsed with `ipaddress.ip_address` — rejects out-of-range octets (`999.1.1.1`) and colon junk the old regexes misclassified as IPv6; dead `_IPV4_RE`/`_IPV6_RE` removed.
- **Corroboration-preserving dedupe**: duplicates merge (tag union) and a cross-source duplicate records `corroborated-by:<source>` on the kept copy — two independent feeds reporting the same indicator is signal. Copy-on-merge, since inputs are often references into adapters' in-process caches.
- **`ProtocolAdapter._collect`** gains a `partial_failure` list parameter so concrete transports can report partially failed collections; `feed_types_fetched` excludes failed sub-feeds. (No concrete subclasses exist yet, so the signature change is safe.)
- **Runtime format checking**: the normalize validator now enforces `"format": "date-time"` on `first_seen`/`last_seen` (`FormatChecker` + `rfc3339-validator` dependency) — previously only CI's negative-fixture check did, against a different schema.
- Cosmetic drift: adapter User-Agents `0.1`/`0.3` → `0.8`; `list_available_feeds` phase label `3` → `4`.

## Test plan

- [x] `cd mcp && python -m pytest tests/ -q` — **193 passed** (176 prior + 17 new)
- [x] `ruff check src/ tests/` — clean
- [x] Outage propagation from both optional and required protocol-credential fields; not-found dual inheritance (`CredentialError` **and** `KeyError`, clean `str()`)
- [x] Breaker: single trial admitted in half-open, concurrent callers rejected, trial slot freed after failure for the next window
- [x] qfeeds: `999.999.999.999` and `foo:bar` rejected; valid IPv4/IPv6 kept
- [x] Dedupe: corroboration tag both orders, no tag for same-source dups, tag union, originals not mutated
- [x] Protocol adapter partial-failure hook end-to-end through `fetch()`
- [x] `first_seen: "not-a-date"` rejected at runtime, valid RFC3339 accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01878u5co184SgiHZDpgxonJ)_